### PR TITLE
Add PHP 5.6 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+    - 5.6
     - 5.5
     - 5.4
     - 5.3


### PR DESCRIPTION
PHP 5.6 is the current PHP major version. The PHP Pagar.me API client should be tested against it.
