### PR TITLE
Adiciona Recipient e Bank Account na API + Adoção de algumas best practices

### DIFF
--- a/lib/Pagarme/Address.php
+++ b/lib/Pagarme/Address.php
@@ -1,4 +1,4 @@
 <?php
+
 class PagarMe_Address extends PagarMe_Model {
 }
-?>

--- a/lib/Pagarme/Bank_Account.php
+++ b/lib/Pagarme/Bank_Account.php
@@ -1,5 +1,4 @@
 <?php
+
 class PagarMe_Bank_Account extends PagarMe_Model {
 }
-
-?>

--- a/lib/Pagarme/Bank_Account.php
+++ b/lib/Pagarme/Bank_Account.php
@@ -1,0 +1,5 @@
+<?php
+class PagarMe_Bank_Account extends PagarMe_Model {
+}
+
+?>

--- a/lib/Pagarme/Card.php
+++ b/lib/Pagarme/Card.php
@@ -1,5 +1,4 @@
 <?php
 
-class PagarMe_Card extends PagarMe_CardHashCommon
-{
+class PagarMe_Card extends PagarMe_CardHashCommon {
 }

--- a/lib/Pagarme/CardHashCommon.php
+++ b/lib/Pagarme/CardHashCommon.php
@@ -1,8 +1,7 @@
 <?php
 
-class PagarMe_CardHashCommon extends PagarMe_Model
-{
-	public function generateCardHash() 
+class PagarMe_CardHashCommon extends PagarMe_Model {
+	public function generateCardHash()
 	{
 		$request = new PagarMe_Request('/transactions/card_hash_key','GET');
 		$response = $request->run();
@@ -15,7 +14,7 @@ class PagarMe_CardHashCommon extends PagarMe_Model
 		);
 		$str = "";
 		foreach($params as $k => $v) {
-			$str .= $k . "=" . $v . "&";	
+			$str .= $k . "=" . $v . "&";
 		}
 		$str = substr($str, 0, -1);
 		openssl_public_encrypt($str,$encrypt, $key);
@@ -43,7 +42,7 @@ class PagarMe_CardHashCommon extends PagarMe_Model
 	{
 		if(!$this->card_hash && $this->shouldGenerateCardHash()) {
 			$this->card_hash = $this->generateCardHash();
-		} 
+		}
 
 		if($this->card_hash) {
 			unset($this->card_holder_name);

--- a/lib/Pagarme/Customer.php
+++ b/lib/Pagarme/Customer.php
@@ -2,5 +2,3 @@
 
 class PagarMe_Customer extends PagarMe_Model {
 }
-
-?>

--- a/lib/Pagarme/Error.php
+++ b/lib/Pagarme/Error.php
@@ -1,6 +1,7 @@
 <?php
+
 class PagarMe_Error {
-        protected $parameter_name, $type, $message;        
+        protected $parameter_name, $type, $message;
 
         public function __construct($error) {
                 $this->parameters_name = $error['parameter_name'];
@@ -12,6 +13,5 @@ class PagarMe_Error {
         public function getParameterName() {return $this->parameter_name;}
         public function getType() {return $this->type;}
         public function getMessage() {return $this->message;}
-        
+
 }
-?>

--- a/lib/Pagarme/Exception.php
+++ b/lib/Pagarme/Exception.php
@@ -1,11 +1,10 @@
 <?php
 
-class PagarMe_Exception extends Exception 
-{
+class PagarMe_Exception extends Exception {
 	protected $url, $method, $return_code, $parameter_name, $type, $errors;
 
 	// Builds with a message and a response from the server
-	public function __construct($message = null, $response_error = null) 
+	public function __construct($message = null, $response_error = null)
 	{
 		$this->url = (isset($response_error['url'])) ? $response_error['url'] : null;
 		$this->method = (isset($response_error['method'])) ? $response_error['method'] : null;
@@ -43,21 +42,18 @@ class PagarMe_Exception extends Exception
 		return $this->errors;
 	}
 
-	public function getUrl() 
+	public function getUrl()
 	{
 		return $this->url;
 	}
 
-	public function getMethod() 
+	public function getMethod()
 	{
 		return $this->method;
 	}
 
-	public function getReturnCode() 
+	public function getReturnCode()
 	{
 		return $this->return_code;
 	}
 }
-
-
-?>

--- a/lib/Pagarme/Model.php
+++ b/lib/Pagarme/Model.php
@@ -1,6 +1,6 @@
 <?php
-class PagarMe_Model extends PagarMe_Object
-{	
+
+class PagarMe_Model extends PagarMe_Object {
 	protected static $root_url;
 
 	public function __construct($response = array()) {
@@ -25,7 +25,7 @@ class PagarMe_Model extends PagarMe_Object
 		}
 	}
 
-	public function save() 
+	public function save()
 	{
 		try {
 			if(method_exists(get_called_class(), 'validate')) {
@@ -42,21 +42,21 @@ class PagarMe_Model extends PagarMe_Object
 	}
 
 
-	public static function findById($id) 
+	public static function findById($id)
 	{
 		$request = new PagarMe_Request(self::getUrl() . '/' . $id, 'GET');
 		$response = $request->run();
-		$class = get_called_class(); 
+		$class = get_called_class();
 		return new $class($response);
 	}
 
-	public static function all($page = 1, $count = 10) 
+	public static function all($page = 1, $count = 10)
 	{
 		$request = new PagarMe_Request(self::getUrl(), 'GET');
 		$request->setParameters(array("page" => $page, "count" => $count));
 		$response = $request->run();
 		$return_array = Array();
-		$class = get_called_class(); 
+		$class = get_called_class();
 		foreach($response as $r) {
 			$return_array[] = new $class($r);
 		}
@@ -64,4 +64,3 @@ class PagarMe_Model extends PagarMe_Object
 		return $return_array;
 	}
 }
-?>

--- a/lib/Pagarme/Object.php
+++ b/lib/Pagarme/Object.php
@@ -43,7 +43,7 @@ class PagarMe_Object implements ArrayAccess, Iterator {
 	public function __call($name, $arguments) {
 		$var = PagarMe_Util::fromCamelCase(substr($name,3));
 		if(!strncasecmp($name, 'get', 3)) {
-			return $this->$var;	
+			return $this->$var;
 		}	else if(!strncasecmp($name, 'set',3)) {
 			$this->$var = $arguments[0];
 		} else {
@@ -92,7 +92,7 @@ class PagarMe_Object implements ArrayAccess, Iterator {
 	}
 
 	public function keys() {
-		return array_keys($this->_attributes);	
+		return array_keys($this->_attributes);
 	}
 
 	public function unsavedArray() {
@@ -111,7 +111,7 @@ class PagarMe_Object implements ArrayAccess, Iterator {
 	}
 
 	public static function build($response, $class = null) {
-		if(!$class) { 
+		if(!$class) {
 			$class = get_class();
 		}
 		$obj = new $class($response);
@@ -119,14 +119,14 @@ class PagarMe_Object implements ArrayAccess, Iterator {
 	}
 
 	public function refresh($response) {
-		$removed = array_diff(array_keys($this->_attributes), array_keys($response));		
+		$removed = array_diff(array_keys($this->_attributes), array_keys($response));
 
 		foreach($removed as $k) {
 			unset($this->$k);
 		}
 
 		foreach($response as $key => $value) {
-			$this->_attributes[$key] = PagarMe_Util::convertToPagarMeObject($value);	
+			$this->_attributes[$key] = PagarMe_Util::convertToPagarMeObject($value);
 			$this->_unsavedAttributes->remove($key);
 		}
 
@@ -182,5 +182,3 @@ class PagarMe_Object implements ArrayAccess, Iterator {
 	}
 
 }
-
-?>

--- a/lib/Pagarme/PagarMe.php
+++ b/lib/Pagarme/PagarMe.php
@@ -1,8 +1,7 @@
 <?php
 
-abstract class PagarMe 
-{
-	public static $api_key; 
+abstract class PagarMe {
+	public static $api_key;
 	const live = 1;
 	const endpoint = "https://api.pagar.me";
 	const api_version = '1';
@@ -13,7 +12,7 @@ abstract class PagarMe
 	}
 
 	public static function setApiKey($api_key) {
-		self::$api_key = $api_key; 
+		self::$api_key = $api_key;
 	}
 
 	public static function getApiKey() {
@@ -24,6 +23,3 @@ abstract class PagarMe
 			return (sha1($id."#".self::$api_key) == $fingerprint);
 	}
 }
-
-
-?>

--- a/lib/Pagarme/Phone.php
+++ b/lib/Pagarme/Phone.php
@@ -1,6 +1,5 @@
 <?php
-class PagarMe_Phone extends PagarMe_Model {
-	
-}
 
-?>
+class PagarMe_Phone extends PagarMe_Model {
+
+}

--- a/lib/Pagarme/Plan.php
+++ b/lib/Pagarme/Plan.php
@@ -1,8 +1,4 @@
 <?php
 
-class PagarMe_Plan extends PagarMe_Model 
-{
+class PagarMe_Plan extends PagarMe_Model {
 }
-
-
-?>

--- a/lib/Pagarme/Recipient.php
+++ b/lib/Pagarme/Recipient.php
@@ -1,0 +1,5 @@
+<?php
+class PagarMe_Recipient extends PagarMe_Model {
+}
+
+?>

--- a/lib/Pagarme/Recipient.php
+++ b/lib/Pagarme/Recipient.php
@@ -1,5 +1,4 @@
 <?php
+
 class PagarMe_Recipient extends PagarMe_Model {
 }
-
-?>

--- a/lib/Pagarme/Request.php
+++ b/lib/Pagarme/Request.php
@@ -1,19 +1,19 @@
 <?php
-class PagarMe_Request extends PagarMe 
-{
+
+class PagarMe_Request extends PagarMe {
 	private $path;
 	private $method;
 	private $parameters = Array();
 	private $headers;
 	private $live;
 
-	public function __construct($path, $method, $live = PagarMe::live) 
+	public function __construct($path, $method, $live = PagarMe::live)
 	{
 		$this->method = $method;
 		$this->path = $path;
-		$this->live = $live;	
+		$this->live = $live;
 	}
-	public function run() 
+	public function run()
 	{
 		if(!parent::getApiKey()) {
 			throw new PagarMe_Exception("You need to configure API key before performing requests.");
@@ -22,7 +22,7 @@ class PagarMe_Request extends PagarMe
 		$this->parameters = array_merge($this->parameters, array( "api_key" => parent::getApiKey()));
 		// var_dump($this->parameters);
 		// $this->headers = (PagarMe::live) ? array("X-Live" => 1) : array();
-		$client = new RestClient(array("method" => $this->method, "url" => $this->full_api_url($this->path), "headers" => $this->headers, "parameters" => $this->parameters ));	
+		$client = new RestClient(array("method" => $this->method, "url" => $this->full_api_url($this->path), "headers" => $this->headers, "parameters" => $this->parameters ));
 		$response = $client->run();
 		$decode = json_decode($response["body"], true);
 		if($decode === NULL) {
@@ -43,9 +43,8 @@ class PagarMe_Request extends PagarMe
 		$this->parameters = $parameters;
 	}
 
-	public function getParameters() 
+	public function getParameters()
 	{
 		return $this->parameters;
 	}
 }
-?>

--- a/lib/Pagarme/RestClient.php
+++ b/lib/Pagarme/RestClient.php
@@ -1,7 +1,6 @@
 <?php
 
-class RestClient 
-{
+class RestClient {
 	private $http_client;
 	private $method;
 	private $url;
@@ -9,7 +8,7 @@ class RestClient
 	private $parameters =  Array();
 	private $curl;
 
-	public function __construct($params = array()) 
+	public function __construct($params = array())
 	{
 		$this->curl = curl_init();
 		$this->headers = array(
@@ -63,12 +62,12 @@ class RestClient
 			}
 		}
 
-		curl_setopt($this->curl, CURLOPT_URL, $this->url);	
+		curl_setopt($this->curl, CURLOPT_URL, $this->url);
 		curl_setopt($this->curl, CURLOPT_HTTPHEADER, $this->headers);
 		curl_setopt($this->curl, CURLOPT_CAINFO, dirname(__FILE__) . '/ca-certificates.crt');
 	}
 
-	public function run() 
+	public function run()
 	{
 		$response = curl_exec($this->curl);
 		$error = curl_error($this->curl);
@@ -85,4 +84,3 @@ class RestClient
 	}
 
 }
-

--- a/lib/Pagarme/Set.php
+++ b/lib/Pagarme/Set.php
@@ -5,7 +5,7 @@ class PagarMe_Set implements Iterator {
 	private $_values;
 	private $_orderedValues;
 	private $_position;
-	
+
 
 	public function __construct(array $members = array()) {
 		$this->_values =  Array();
@@ -18,7 +18,7 @@ class PagarMe_Set implements Iterator {
 			}
 			$this->_values[$m] = true;
 		}
-	}	
+	}
 
 	public function includes($member) {
 		return isset($this->_values[$member]);
@@ -56,5 +56,3 @@ class PagarMe_Set implements Iterator {
 		return isset($this->_orderedValues[$this->_position]);
 	}
 }
-
-?>

--- a/lib/Pagarme/Subscription.php
+++ b/lib/Pagarme/Subscription.php
@@ -1,4 +1,5 @@
 <?php
+
 class PagarMe_Subscription extends PagarMe_TransactionCommon {
 
 	public function create() {
@@ -42,4 +43,3 @@ class PagarMe_Subscription extends PagarMe_TransactionCommon {
 			$this->refresh($response);
 	}
 }
-?>

--- a/lib/Pagarme/Transaction.php
+++ b/lib/Pagarme/Transaction.php
@@ -1,7 +1,8 @@
 <?php
+
 class PagarMe_Transaction extends PagarMe_TransactionCommon {
 
-	public function charge() 
+	public function charge()
 	{
 		$this->create();
 	}
@@ -9,14 +10,14 @@ class PagarMe_Transaction extends PagarMe_TransactionCommon {
 	public function capture($amount = false)
 	{
 			$request = new PagarMe_Request(self::getUrl().'/'.$this->id . '/capture', 'POST');
-			if($amount) { 
+			if($amount) {
 				$request->setParameters(array('amount' => $amount));
 			}
 			$response = $request->run();
 			$this->refresh($response);
 	}
 
-	public function refund($params = array()) 
+	public function refund($params = array())
 	{
 			$request = new PagarMe_Request(self::getUrl().'/'.$this->id . '/refund', 'POST');
 			$request->setParameters($params);
@@ -24,5 +25,3 @@ class PagarMe_Transaction extends PagarMe_TransactionCommon {
 			$this->refresh($response);
 	}
 }
-
-?>

--- a/lib/Pagarme/TransactionCommon.php
+++ b/lib/Pagarme/TransactionCommon.php
@@ -1,9 +1,9 @@
 <?php
-class PagarMe_TransactionCommon extends PagarMe_CardHashCommon 
-{
+
+class PagarMe_TransactionCommon extends PagarMe_CardHashCommon {
 	public function __construct($response = array())
 	{
-		parent::__construct($response);			
+		parent::__construct($response);
 		if(!isset($this->payment_method)) {
 			$this->payment_method = 'credit_card';
 		}
@@ -11,7 +11,7 @@ class PagarMe_TransactionCommon extends PagarMe_CardHashCommon
 		if(!isset($this->status)) {
 			$this->status = 'local';
 		}
-	} 
+	}
 
 	protected function checkCard()
 	{
@@ -46,10 +46,10 @@ class PagarMe_TransactionCommon extends PagarMe_CardHashCommon
 	public static function calculateInstallmentsAmount($amount, $interest_rate, $max_installments)
 	{
 		$request = new PagarMe_Request(self::getUrl() . '/calculate_installments_amount', 'GET');
-		$params = array('amount' => $amount, 'interest_rate' => $interest_rate, 'max_installments' => $max_installments);	
+		$params = array('amount' => $amount, 'interest_rate' => $interest_rate, 'max_installments' => $max_installments);
 		$request->setParameters($params);
 		$response = $request->run();
-		
+
 		return $response;
 	}
 
@@ -65,4 +65,3 @@ class PagarMe_TransactionCommon extends PagarMe_CardHashCommon
 		return $hasUnsavedCardAttrbutes;
 	}
 }
-

--- a/lib/Pagarme/Util.php
+++ b/lib/Pagarme/Util.php
@@ -64,7 +64,7 @@ class PagarMe_Util {
 			return $output;
 		} else if(is_array($response)) {
 			if(isset($response['object']) && is_string($response['object']) && isset($types[$response['object']])) {
-				$class = $types[$response['object']];	
+				$class = $types[$response['object']];
 			} else {
 				$class = 'PagarMe_Object';
 			}
@@ -73,8 +73,6 @@ class PagarMe_Util {
 		} else {
 			return $response;
 		}
-	}	
+	}
 
 }
-
-?>

--- a/tests/PagarMe/Object.php
+++ b/tests/PagarMe/Object.php
@@ -1,7 +1,6 @@
 <?php
 
 class PagarMe_ObjectTest extends  PagarMeTestCase {
-	
 	public function testBuild() {
 		$obj = self::createPagarMeObject();
 		$this->assertTrue($obj instanceof PagarMe_Transaction);
@@ -26,7 +25,7 @@ class PagarMe_ObjectTest extends  PagarMeTestCase {
 
 		foreach($obj as $k => $v) {
 			$this->assertTrue($k);
-			$this->assertTrue($v);	
+			$this->assertTrue($v);
 			$count++;
 		}
 
@@ -42,4 +41,3 @@ class PagarMe_ObjectTest extends  PagarMeTestCase {
 		$this->assertFalse($obj->card_brand);
 	}
 }
-?>

--- a/tests/PagarMe/Plan.php
+++ b/tests/PagarMe/Plan.php
@@ -13,16 +13,16 @@ class PagarMe_PlanTest extends PagarMeTestCase {
 		$this->assertEqual($plan->getName(), "Plano Silver");
 		$plan->setName("Plano gold!");
 		$plan->save();
-		$plan2 = PagarMe_Plan::findById($plan->getId());		
+		$plan2 = PagarMe_Plan::findById($plan->getId());
 		$this->assertEqual($plan->getName(), $plan2->getName());
 
 		$this->expectException(new IsAExpectation('PagarMe_Exception'));
 		$plan2->setDays('60');
 		$plan2->save();
-	} 
+	}
 
 	public function testUpdatePaymentMethods() {
-		$plan = self::createTestPlan();	
+		$plan = self::createTestPlan();
 		$plan->create();
 		$this->assertTrue(in_array('credit_card', $plan->getPaymentMethods()));
 		$this->assertTrue(in_array('boleto', $plan->getPaymentMethods()));
@@ -62,5 +62,3 @@ class PagarMe_PlanTest extends PagarMeTestCase {
 		$plan->assertTrue($plan->getId());
 	}
 }
-
-?>

--- a/tests/PagarMe/Set.php
+++ b/tests/PagarMe/Set.php
@@ -38,4 +38,3 @@ class PagarMe_SetTest extends PagarMeTestCase {
 		$this->assertTrue($count == 5);
 	}
 }
-?>

--- a/tests/PagarMe/Subscription.php
+++ b/tests/PagarMe/Subscription.php
@@ -3,7 +3,7 @@
 class PagarMe_SubscriptionTest extends PagarMeTestCase {
 
 	public function testCreate() {
-		$subscription = self::createTestSubscription();	
+		$subscription = self::createTestSubscription();
 		$subscription->create();
 		$this->validateSubscription($subscription);
 	}
@@ -155,7 +155,7 @@ class PagarMe_SubscriptionTest extends PagarMeTestCase {
 		$this->assertEqual($transaction->getInstallments(), '1');
 		$this->assertEqual($transaction->getAmount(), '3600');
 	}
-	
+
 	public function testChargeWithInstallments() {
 		$subscription = self::createTestSubscription();
 		$subscription->create();
@@ -165,5 +165,3 @@ class PagarMe_SubscriptionTest extends PagarMeTestCase {
 		$this->assertEqual($transaction->getInstallments(), '3');
 	}
 }
-
-?>

--- a/tests/PagarMe/TestCase.php
+++ b/tests/PagarMe/TestCase.php
@@ -1,20 +1,19 @@
 <?php
 
 abstract class PagarMeTestCase extends UnitTestCase {
-	
+
 
 	protected static function setAntiFraud($status) {
-		// authorizeFromEnv();	
+		// authorizeFromEnv();
 		// $request = new PagarMe_Request('/company', 'PUT');
-		// $request->setParameters(array('antifraud' => $status));	
+		// $request->setParameters(array('antifraud' => $status));
 		// $response = $request->run();
 	}
 
-	protected static function createTestTransaction(array $attributes = array()) 
-	{
-		authorizeFromEnv();	
+	protected static function createTestTransaction(array $attributes = array()) {
+		authorizeFromEnv();
 		return new PagarMe_Transaction(
-			$attributes + 
+			$attributes +
 			array(
 			"amount" => '1000',
 			"card_number" => "4901720080344448",
@@ -27,23 +26,23 @@ abstract class PagarMeTestCase extends UnitTestCase {
 
 	protected static function createTestCustomer(array $attributes = array()) {
 		$customer = array(
-			'name' => "Jose da Silva",  
-			'document_number' => "36433809847", 
-			'email' => "customer@pagar.me", 
+			'name' => "Jose da Silva",
+			'document_number' => "36433809847",
+			'email' => "customer@pagar.me",
 			'address' => array(
 				'street' => "Av Faria Lima",
 				'neighborhood' => 'Jardim Europa',
-				'zipcode' => '01452000', 
-				'street_number' => '296', 
+				'zipcode' => '01452000',
+				'street_number' => '296',
 				'complementary' => '8 andar'
 			),
 			'phone' => array(
-				'ddd' => '12', 
-				'number' => '999999999', 
+				'ddd' => '12',
+				'number' => '999999999',
 			),
-			'sex' => 'M', 
+			'sex' => 'M',
 			'born_at' => '1995-10-11');
-		return $customer;	
+		return $customer;
 	}
 
 	protected static function createTestCard(array $attributes = array()) {
@@ -58,23 +57,23 @@ abstract class PagarMeTestCase extends UnitTestCase {
 	}
 
 	protected static function createTestTransactionWithCustomer(array $attributes = array()) {
-		authorizeFromEnv();	
+		authorizeFromEnv();
 		$transaction = self::createTestTransaction();
 		$transaction->customer = self::createTestCustomer();
 		return $transaction;
 	}
 
 	protected static function createTestPlan(array $attributes = array()) {
-		authorizeFromEnv();		
+		authorizeFromEnv();
 		return new PagarMe_Plan($attributes +
 			array(
 				'amount' => 1000,
 				'days' => '30',
 				'name' => "Plano Silver",
-				'trial_days' => '2'	
+				'trial_days' => '2'
 			)
 		);
-	}	
+	}
 
 	protected function validatePlan($plan) {
 		$this->assertTrue($plan->getId());
@@ -82,10 +81,10 @@ abstract class PagarMeTestCase extends UnitTestCase {
 		$this->assertEqual($plan->getName(), 'Plano Silver');
 		$this->assertEqual($plan->getTrialDays(), '2');
 	}
-	
+
 
 	protected static function createTestSubscription(array $attributes = array()) {
-		authorizeFromEnv();	
+		authorizeFromEnv();
 		return new PagarMe_Subscription($attributes + array(
 			"card_number" => "4901720080344448",
 			"card_holder_name" => "Jose da Silva",
@@ -106,7 +105,7 @@ abstract class PagarMeTestCase extends UnitTestCase {
 	}
 
 	protected function validateCustomerResponse($customer) {
-		authorizeFromEnv();	
+		authorizeFromEnv();
 		$this->assertTrue($customer->getId());
 		$this->assertEqual($customer->getDocumentType(), 'cpf');
 		$this->assertEqual($customer->getName(), 'Jose da Silva');
@@ -159,7 +158,7 @@ abstract class PagarMeTestCase extends UnitTestCase {
 	protected function validateSubscription($subscription) {
 		if($subscription->getCustomer()->getName()) {
 			$this->validateCustomerResponse($subscription->getCustomer());
-		}	
+		}
 
 		if($subscription->getPlan()) {
 			$this->validatePlan($subscription->getPlan());
@@ -170,9 +169,9 @@ abstract class PagarMeTestCase extends UnitTestCase {
 	}
 
 	protected function validateTransactionResponse($transaction) {
-		authorizeFromEnv();	
-		
-		$this->assertTrue($transaction->getId());	
+		authorizeFromEnv();
+
+		$this->assertTrue($transaction->getId());
 
 		if ($transaction->getPaymentMethod() == 'credit_card') {
 			$this->assertEqual($transaction->getCardHolderName(), 'Jose da Silva');
@@ -186,7 +185,7 @@ abstract class PagarMeTestCase extends UnitTestCase {
 
 		if($transaction->getCustomer()) {
 			$customer = $transaction->getCustomer();
-			$this->validateCustomerResponse($customer);	
+			$this->validateCustomerResponse($customer);
 		}
 
 		if($transaction->getAddress()) {
@@ -199,5 +198,3 @@ abstract class PagarMeTestCase extends UnitTestCase {
 	}
 
 }
-
-?>

--- a/tests/PagarMe/Transaction.php
+++ b/tests/PagarMe/Transaction.php
@@ -16,7 +16,7 @@ class PagarMe_TransactionTest extends PagarMeTestCase {
 	}
 
 	public function testPostbackUrl() {
-		$t = self::createTestTransaction();	
+		$t = self::createTestTransaction();
 		$t->setPostbackUrl('http://url.com');
 		$t->charge();
 
@@ -25,7 +25,7 @@ class PagarMe_TransactionTest extends PagarMeTestCase {
 
 	public function testCalculateInstallmentsAmount() {
 		$request = PagarMe_Transaction::calculateInstallmentsAmount('10000', '1.5', '12');
-		$installments = $request['installments'];	
+		$installments = $request['installments'];
 		$this->assertEqual($installments["5"]["amount"], '10471');
 		$this->assertEqual($installments["5"]["installment"],  '5');
 		$this->assertEqual($installments["5"]["installment_amount"],  '2094');
@@ -63,7 +63,7 @@ class PagarMe_TransactionTest extends PagarMeTestCase {
 		$this->assertEqual($t->getAmount(), 1000);
 		$this->assertEqual($t->getStatus(), 'paid');
 	}
-	
+
 	public function testPostbackUrlWithCardHash() {
 		$t = self::createTestTransactionWithCustomer();
 		$card_hash = $t->generateCardHash();
@@ -196,7 +196,7 @@ class PagarMe_TransactionTest extends PagarMeTestCase {
 		$transaction = self::createTestTransaction();
 		$this->assertEqual($transaction->getStatus(), 'local');
 		$this->assertEqual($transaction->getPaymentMethod(), 'credit_card');
-	} 
+	}
 
 	public function testMetadata() {
 		$transaction = self::createTestTransaction();
@@ -254,10 +254,7 @@ class PagarMe_TransactionTest extends PagarMeTestCase {
 		$transaction->setAmount(1000);
 	}
 
-
 	public function testFingerprint() {
-		$this->assertTrue(PagarMe::validateFingerprint('13', sha1('13' . '#' . PagarMe::getApiKey())));		
+		$this->assertTrue(PagarMe::validateFingerprint('13', sha1('13' . '#' . PagarMe::getApiKey())));
 	}
 }
-
-?>

--- a/tests/PagarMe/Util.php
+++ b/tests/PagarMe/Util.php
@@ -1,15 +1,15 @@
 <?php
 
 class PagarMe_UtilTest extends PagarMeTestCase {
-	
+
 	public function testIsList() {
 		$arr1 = '123';
 		$arr2 = array('abc' => 'bcd', '456' => 'bcd');
 		$arr3 = array('abc', 'bcd', 'def');
 
-		$this->assertFalse(PagarMe_Util::isList($arr1));	
-		$this->assertFalse(PagarMe_Util::isList($arr2));	
-		$this->assertTrue(PagarMe_Util::isList($arr3));	
+		$this->assertFalse(PagarMe_Util::isList($arr1));
+		$this->assertFalse(PagarMe_Util::isList($arr2));
+		$this->assertTrue(PagarMe_Util::isList($arr3));
 	}
 
 	public function testCamelCase() {
@@ -62,5 +62,3 @@ class PagarMe_UtilTest extends PagarMeTestCase {
 		$this->assertTrue($obj->customer->address instanceof PagarMe_Address);
 	}
 }
-
-?>

--- a/tests/Pagarme.php
+++ b/tests/Pagarme.php
@@ -2,27 +2,29 @@
 
 function authorizeFromEnv()
 {
-  $apiKey = getenv('PAGARME_API_KEY');
-  if (!$apiKey)
-    $apiKey = "ak_test_Rw4JR98FmYST2ngEHtMvVf5QJW7Eoo";
-  PagarMe::setApiKey($apiKey);
+    $apiKey = getenv('PAGARME_API_KEY');
+    if (!$apiKey)
+        $apiKey = "ak_test_Rw4JR98FmYST2ngEHtMvVf5QJW7Eoo";
+    PagarMe::setApiKey($apiKey);
 }
 
 $ok = @include_once(dirname(__FILE__).'/simpletest/autorun.php');
 if (!$ok) {
-  $ok = @include_once(dirname(__FILE__).'/../vendor/simpletest/simpletest/autorun.php');
+    $ok = @include_once(dirname(__FILE__).'/../vendor/simpletest/simpletest/autorun.php');
 }
+
 if (!$ok) {
-  echo "MISSING DEPENDENCY: The PagarMe API test cases depend on SimpleTest. ".
-       "Download it at <http://www.simpletest.org/>, and either install it ".
-       "in your PHP include_path or put it in the test/ directory.\n";
-  exit(1);
+    echo "MISSING DEPENDENCY: The PagarMe API test cases depend on SimpleTest. ".
+         "Download it at <http://www.simpletest.org/>, and either install it ".
+         "in your PHP include_path or put it in the test/ directory.\n";
+    exit(1);
 }
 
 // Throw an exception on any error
 function exception_error_handler($errno, $errstr, $errfile, $errline) {
-  throw new ErrorException($errstr, $errno, 0, $errfile, $errline);
+    throw new ErrorException($errstr, $errno, 0, $errfile, $errline);
 }
+
 set_error_handler('exception_error_handler');
 error_reporting(E_ALL | E_STRICT);
 
@@ -34,6 +36,3 @@ require_once(dirname(__FILE__) . '/PagarMe/Set.php');
 require_once(dirname(__FILE__) . '/PagarMe/Transaction.php');
 require_once(dirname(__FILE__) . '/PagarMe/Plan.php');
 require_once(dirname(__FILE__) . '/PagarMe/Subscription.php');
-
-
-?>


### PR DESCRIPTION
Adição de classes para trabalhar com Recipients e Bank Accounts

Usar a tag de fechamento do PHP deve ser omitida para não causar alguns possíveis erros (http://stackoverflow.com/questions/4410704/why-would-one-omit-the-close-tag)

Alterações simples de style do código