### PR TITLE
Adicionar Bank_Account e Recipient à biblioteca PHP

### DIFF
--- a/Pagarme.php
+++ b/Pagarme.php
@@ -37,9 +37,11 @@ require(dirname(__FILE__) . '/lib/Pagarme/TransactionCommon.php');
 require(dirname(__FILE__) . '/lib/Pagarme/Transaction.php');
 require(dirname(__FILE__) . '/lib/Pagarme/Plan.php');
 require(dirname(__FILE__) . '/lib/Pagarme/Subscription.php');
-require(dirname(__FILE__) . '/lib/Pagarme/Customer.php');
 require(dirname(__FILE__) . '/lib/Pagarme/Address.php');
 require(dirname(__FILE__) . '/lib/Pagarme/Phone.php');
 require(dirname(__FILE__) . '/lib/Pagarme/Card.php');
+require(dirname(__FILE__) . '/lib/Pagarme/Bank_Account.php');
+require(dirname(__FILE__) . '/lib/Pagarme/Recipient.php');
+require(dirname(__FILE__) . '/lib/Pagarme/Customer.php');
 
 ?>

--- a/tests/PagarMe/Bank_Account.php
+++ b/tests/PagarMe/Bank_Account.php
@@ -1,0 +1,20 @@
+<?php
+
+class PagarMe_Bank_AccountTest extends PagarMeTestCase {
+	public function testCreate() {
+		$bank = self::createTestBankAccount();
+		$bank->create();
+
+		$this->assertTrue($bank->getId());
+		$this->assertEqual($bank->getBankCode(), "341");
+		$this->assertEqual($bank->getAgencia(), "0932");
+		$this->assertEqual($bank->getAgenciaDv(), "5");
+		$this->assertEqual($bank->getConta(), "58054");
+		$this->assertEqual($bank->getContaDv(), "1");
+		$this->assertEqual($bank->getDocumentType(), "cpf");
+		$this->assertEqual($bank->getDocumentNumber(), "26268738888");
+		$this->assertEqual($bank->getLegalName(), "API BANK ACCOUNT");
+		$this->assertTrue($bank->getChargeTransferFees());
+		$this->assertTrue($bank->getDateCreated());
+	}
+}

--- a/tests/PagarMe/Recipient.php
+++ b/tests/PagarMe/Recipient.php
@@ -1,0 +1,33 @@
+<?php
+
+class PagarMe_RecipientTest extends PagarMeTestCase {
+	public function testCreate() {
+		$r = self::createTestRecipient();
+		$r->create();
+		
+		$this->assertTrue($r->getId());
+
+		$bank = $r->getBankAccount();
+		$this->assertTrue($bank->getId());
+		$this->assertEqual($bank->getBankCode(), "341");
+		$this->assertEqual($bank->getAgencia(), "0932");
+		$this->assertEqual($bank->getAgenciaDv(), "5");
+		$this->assertEqual($bank->getConta(), "58054");
+		$this->assertEqual($bank->getContaDv(), "1");
+		$this->assertEqual($bank->getDocumentType(), "cpf");
+		$this->assertEqual($bank->getDocumentNumber(), "26268738888");
+		$this->assertEqual($bank->getLegalName(), "API BANK ACCOUNT");
+		$this->assertTrue($bank->getChargeTransferFees());
+		$this->assertTrue($bank->getDateCreated());
+
+		$this->assertTrue($r->getTransferEnabled());
+		$this->assertEqual($r->getLastTransfer(), NULL);
+		$this->assertEqual($r->getTransferInterval(), "weekly");
+		$this->assertEqual($r->getTransferDay(), "5");
+		$this->assertTrue($r->getAutomaticAnticipationEnabled());
+		$this->assertEqual($r->getAnticipatableVolumePercentage(), 85);
+		$this->assertTrue($r->getDateCreated());
+		$this->assertTrue($r->getDateUpdated());
+	}
+}
+

--- a/tests/PagarMe/TestCase.php
+++ b/tests/PagarMe/TestCase.php
@@ -97,6 +97,41 @@ abstract class PagarMeTestCase extends UnitTestCase {
 		));
 	}
 
+	protected static function createTestBankAccount(array $attributes = array()) {
+		authorizeFromEnv();
+
+		return new PagarMe_Bank_Account(array(
+			"bank_code" => "341",
+			"agencia" => "0932",
+			"agencia_dv" => "5",
+			"conta" => "58054",
+			"conta_dv" => "1",
+			"document_number" => "26268738888",
+			"legal_name" => "API BANK ACCOUNT"
+		));
+	}
+
+	protected static function createTestRecipient(array $attributes = array()) {
+		authorizeFromEnv();
+
+		return new PagarMe_Recipient(array(
+			"transfer_interval" => "weekly",
+			"transfer_day" => 5,
+			"transfer_enabled" => true,
+			"automatic_anticipation_enabled" => true,
+			"anticipatable_volume_percentage" => 85,
+			"bank_account" => array(
+				"bank_code" => "341",
+				"agencia" => "0932",
+				"agencia_dv" => "5",
+				"conta" => "58054",
+				"conta_dv" => "1",
+				"document_number" => "26268738888",
+				"legal_name" => "API BANK ACCOUNT",
+			)
+		));
+	}	
+
 	protected static function createSubscriptionWithCustomer(array $attributes = array()) {
 		authorizeFromEnv();
 		$subscription = self::createTestSubscription();

--- a/tests/Pagarme.php
+++ b/tests/Pagarme.php
@@ -36,3 +36,5 @@ require_once(dirname(__FILE__) . '/PagarMe/Set.php');
 require_once(dirname(__FILE__) . '/PagarMe/Transaction.php');
 require_once(dirname(__FILE__) . '/PagarMe/Plan.php');
 require_once(dirname(__FILE__) . '/PagarMe/Subscription.php');
+require_once(dirname(__FILE__) . '/PagarMe/Bank_Account.php');
+require_once(dirname(__FILE__) . '/PagarMe/Recipient.php');


### PR DESCRIPTION
Já haviam models que permitiam a criação/consulta por id/consulta de todos os recipientes e contas bancárias. Entretanto, eles não estavam `require`d no `Pagarme.php` no root.

Além disso, não haviam testes para esses dois modelos, que foram adicionados.