### PR TITLE
Remove literals

### DIFF
--- a/lib/Calculation/Request/CalculateInstallmentsRequest.php
+++ b/lib/Calculation/Request/CalculateInstallmentsRequest.php
@@ -70,6 +70,6 @@ class CalculateInstallmentsRequest implements Request
      */
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Card/Request/CardCreate.php
+++ b/lib/Card/Request/CardCreate.php
@@ -58,6 +58,6 @@ class CardCreate implements Request
      */
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 }

--- a/lib/Card/Request/CardGet.php
+++ b/lib/Card/Request/CardGet.php
@@ -40,6 +40,6 @@ class CardGet implements Request
      */
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Company/Request/CompanyInfo.php
+++ b/lib/Company/Request/CompanyInfo.php
@@ -27,6 +27,6 @@ class CompanyInfo implements Request
      */
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Customer/Request/CustomerCreate.php
+++ b/lib/Customer/Request/CustomerCreate.php
@@ -99,7 +99,7 @@ class CustomerCreate implements Request
      */
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 
     /**

--- a/lib/Customer/Request/CustomerGet.php
+++ b/lib/Customer/Request/CustomerGet.php
@@ -40,6 +40,6 @@ class CustomerGet implements Request
      */
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Customer/Request/CustomerList.php
+++ b/lib/Customer/Request/CustomerList.php
@@ -50,6 +50,6 @@ class CustomerList implements Request
      */
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Plan/Request/PlanCreate.php
+++ b/lib/Plan/Request/PlanCreate.php
@@ -108,6 +108,6 @@ class PlanCreate implements Request
      */
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 }

--- a/lib/Plan/Request/PlanGet.php
+++ b/lib/Plan/Request/PlanGet.php
@@ -41,6 +41,6 @@ class PlanGet implements Request
      */
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Plan/Request/PlanList.php
+++ b/lib/Plan/Request/PlanList.php
@@ -51,6 +51,6 @@ class PlanList implements Request
      */
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Plan/Request/PlanUpdate.php
+++ b/lib/Plan/Request/PlanUpdate.php
@@ -49,6 +49,6 @@ class PlanUpdate implements Request
      */
     public function getMethod()
     {
-        return 'PUT';
+        return self::HTTP_PUT;
     }
 }

--- a/lib/Recipient/Request/RecipientBalance.php
+++ b/lib/Recipient/Request/RecipientBalance.php
@@ -29,6 +29,6 @@ class RecipientBalance implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Recipient/Request/RecipientBalanceOperation.php
+++ b/lib/Recipient/Request/RecipientBalanceOperation.php
@@ -34,6 +34,6 @@ class RecipientBalanceOperation implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Recipient/Request/RecipientBalanceOperations.php
+++ b/lib/Recipient/Request/RecipientBalanceOperations.php
@@ -37,6 +37,6 @@ class RecipientBalanceOperations implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Recipient/Request/RecipientCreate.php
+++ b/lib/Recipient/Request/RecipientCreate.php
@@ -51,7 +51,7 @@ class RecipientCreate implements Request
 
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 
     protected function getBankAccountData()

--- a/lib/Recipient/Request/RecipientGet.php
+++ b/lib/Recipient/Request/RecipientGet.php
@@ -29,6 +29,6 @@ class RecipientGet implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Recipient/Request/RecipientList.php
+++ b/lib/Recipient/Request/RecipientList.php
@@ -31,6 +31,6 @@ class RecipientList implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Recipient/Request/RecipientUpdate.php
+++ b/lib/Recipient/Request/RecipientUpdate.php
@@ -62,6 +62,6 @@ class RecipientUpdate implements Request
      */
     public function getMethod()
     {
-        return 'PUT';
+        return self::HTTP_PUT;
     }
 }

--- a/lib/Subscription/Request/SubscriptionCancel.php
+++ b/lib/Subscription/Request/SubscriptionCancel.php
@@ -31,6 +31,6 @@ class SubscriptionCancel implements Request
 
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 }

--- a/lib/Subscription/Request/SubscriptionCreate.php
+++ b/lib/Subscription/Request/SubscriptionCreate.php
@@ -76,7 +76,7 @@ abstract class SubscriptionCreate implements Request
 
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 
     /**

--- a/lib/Subscription/Request/SubscriptionGet.php
+++ b/lib/Subscription/Request/SubscriptionGet.php
@@ -31,6 +31,6 @@ class SubscriptionGet implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Subscription/Request/SubscriptionList.php
+++ b/lib/Subscription/Request/SubscriptionList.php
@@ -41,6 +41,6 @@ class SubscriptionList implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Subscription/Request/SubscriptionTransactionsGet.php
+++ b/lib/Subscription/Request/SubscriptionTransactionsGet.php
@@ -35,6 +35,6 @@ class SubscriptionTransactionsGet implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Subscription/Request/SubscriptionUpdate.php
+++ b/lib/Subscription/Request/SubscriptionUpdate.php
@@ -51,6 +51,6 @@ class SubscriptionUpdate implements Request
      */
     public function getMethod()
     {
-        return 'PUT';
+        return self::HTTP_PUT;
     }
 }

--- a/lib/Transaction/Request/BoletoTransactionRefund.php
+++ b/lib/Transaction/Request/BoletoTransactionRefund.php
@@ -40,7 +40,7 @@ class BoletoTransactionRefund implements Request
 
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 
     private function getBankAccountData()

--- a/lib/Transaction/Request/CreditCardTransactionRefund.php
+++ b/lib/Transaction/Request/CreditCardTransactionRefund.php
@@ -33,6 +33,6 @@ class CreditCardTransactionRefund implements Request
 
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 }

--- a/lib/Transaction/Request/TransactionCapture.php
+++ b/lib/Transaction/Request/TransactionCapture.php
@@ -35,6 +35,6 @@ class TransactionCapture implements Request
 
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 }

--- a/lib/Transaction/Request/TransactionCreate.php
+++ b/lib/Transaction/Request/TransactionCreate.php
@@ -67,7 +67,7 @@ class TransactionCreate implements Request
 
     public function getMethod()
     {
-        return 'POST';
+        return self::HTTP_POST;
     }
 
     private function getSplitRulesInfo(SplitRuleCollection $splitRules)

--- a/lib/Transaction/Request/TransactionGet.php
+++ b/lib/Transaction/Request/TransactionGet.php
@@ -28,6 +28,6 @@ class TransactionGet implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/lib/Transaction/Request/TransactionList.php
+++ b/lib/Transaction/Request/TransactionList.php
@@ -30,6 +30,6 @@ class TransactionList implements Request
 
     public function getMethod()
     {
-        return 'GET';
+        return self::HTTP_GET;
     }
 }

--- a/tests/unit/AntifraudAnalyses/Request/AntifraudAnalysesGetTest.php
+++ b/tests/unit/AntifraudAnalyses/Request/AntifraudAnalysesGetTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\AntifraudAnalyses\Request;
 
 use PagarMe\Sdk\AntifraudAnalyses\Request\AntifraudAnalysesGet;
+use PagarMe\Sdk\Request;
 
 class AntifraudAnalysesGetTest extends \PHPUnit_Framework_TestCase
 {
     const PATH                  = 'transactions/112233/antifraud_analyses/123';
-    const METHOD                = 'GET';
     const TRANSACTION_ID        = 112233;
     const ANTIFRAUD_ANALYSES_ID = 123;
 
@@ -30,7 +30,10 @@ class AntifraudAnalysesGetTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals([], $antifraudAnalysesGet->getPayload());
-        $this->assertEquals(self::METHOD, $antifraudAnalysesGet->getMethod());
+        $this->assertEquals(
+            Request::HTTP_GET,
+            $antifraudAnalysesGet->getMethod()
+        );
         $this->assertEquals(self::PATH, $antifraudAnalysesGet->getPath());
     }
 }

--- a/tests/unit/AntifraudAnalyses/Request/AntifraudAnalysesListTest.php
+++ b/tests/unit/AntifraudAnalyses/Request/AntifraudAnalysesListTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\AntifraudAnalyses\Request;
 
 use PagarMe\Sdk\AntifraudAnalyses\Request\AntifraudAnalysesList;
+use PagarMe\Sdk\Request;
 
 class AntifraudAnalysesListTest extends \PHPUnit_Framework_TestCase
 {
     const PATH           = 'transactions/112233/antifraud_analyses';
-    const METHOD         = 'GET';
     const TRANSACTION_ID = 112233;
 
     /**
@@ -26,7 +26,7 @@ class AntifraudAnalysesListTest extends \PHPUnit_Framework_TestCase
         $antifraudAnalysesList = new AntifraudAnalysesList($transactionMock);
 
         $this->assertEquals([], $antifraudAnalysesList->getPayload());
-        $this->assertEquals(self::METHOD, $antifraudAnalysesList->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $antifraudAnalysesList->getMethod());
         $this->assertEquals(self::PATH, $antifraudAnalysesList->getPath());
     }
 }

--- a/tests/unit/BalanceOperations/Request/BalanceOperationsGetTest.php
+++ b/tests/unit/BalanceOperations/Request/BalanceOperationsGetTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\BalanceOperations\Request;
 
 use PagarMe\Sdk\BalanceOperations\Request\BalanceOperationsGet;
+use PagarMe\Sdk\Request;
 
 class BalanceOperationsGetTest extends \PHPUnit_Framework_TestCase
 {
     const PATH                  = 'balance/operations/123';
-    const METHOD                = 'GET';
     const BALANCE_OPERATIONS_ID = '123';
 
     /**
@@ -17,7 +17,7 @@ class BalanceOperationsGetTest extends \PHPUnit_Framework_TestCase
     {
         $request = new BalanceOperationsGet(self::BALANCE_OPERATIONS_ID);
 
-        $this->assertEquals(self::METHOD, $request->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $request->getMethod());
         $this->assertEquals(self::PATH, $request->getPath());
         $this->assertEquals([], $request->getPayload());
     }

--- a/tests/unit/BalanceOperations/Request/BalanceOperationsListTest.php
+++ b/tests/unit/BalanceOperations/Request/BalanceOperationsListTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\BalanceOperations\Request;
 
 use PagarMe\Sdk\BalanceOperations\Request\BalanceOperationsList;
+use PagarMe\Sdk\Request;
 
 class BalanceOperationsListTest extends \PHPUnit_Framework_TestCase
 {
-    const PATH            = 'balance/operations';
-    const METHOD          = 'GET';
+    const PATH = 'balance/operations';
 
     public function balanceOperationsListParams()
     {
@@ -31,7 +31,7 @@ class BalanceOperationsListTest extends \PHPUnit_Framework_TestCase
             $status
         );
 
-        $this->assertEquals(self::METHOD, $request->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $request->getMethod());
         $this->assertEquals(self::PATH, $request->getPath());
         $this->assertEquals(
             [

--- a/tests/unit/BankAccount/Request/BankAccountCreateTest.php
+++ b/tests/unit/BankAccount/Request/BankAccountCreateTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\BankAccount\Request;
 
 use PagarMe\Sdk\BankAccount\Request\BankAccountCreate;
+use PagarMe\Sdk\Request;
 
 class BankAccountCreateTest extends \PHPUnit_Framework_TestCase
 {
     const PATH            = 'bank_accounts';
-    const METHOD          = 'POST';
 
     public function accountDataProvider()
     {
@@ -43,7 +43,7 @@ class BankAccountCreateTest extends \PHPUnit_Framework_TestCase
             $agenciaDv
         );
 
-        $this->assertEquals(self::METHOD, $bankAccountCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $bankAccountCreate->getMethod());
         $this->assertEquals(self::PATH, $bankAccountCreate->getPath());
         $this->assertEquals(
             [

--- a/tests/unit/BankAccount/Request/BankAccountGetTest.php
+++ b/tests/unit/BankAccount/Request/BankAccountGetTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\BankAccount\Request;
 
 use PagarMe\Sdk\BankAccount\Request\BankAccountGet;
+use PagarMe\Sdk\Request;
 
 class BankAccountGetTest extends \PHPUnit_Framework_TestCase
 {
     const PATH            = 'bank_accounts/1337';
-    const METHOD          = 'GET';
     const BANK_ACCOUNT_ID = '1337';
 
     /**
@@ -17,7 +17,7 @@ class BankAccountGetTest extends \PHPUnit_Framework_TestCase
     {
         $request = new BankAccountGet(self::BANK_ACCOUNT_ID);
 
-        $this->assertEquals(self::METHOD, $request->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $request->getMethod());
         $this->assertEquals(self::PATH, $request->getPath());
         $this->assertEquals(
             [],

--- a/tests/unit/BankAccount/Request/BankAccountListTest.php
+++ b/tests/unit/BankAccount/Request/BankAccountListTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\BankAccount\Request;
 
 use PagarMe\Sdk\BankAccount\Request\BankAccountList;
+use PagarMe\Sdk\Request;
 
 class BankAccountListTest extends \PHPUnit_Framework_TestCase
 {
-    const PATH            = 'bank_accounts';
-    const METHOD          = 'GET';
+    const PATH = 'bank_accounts';
 
     public function bankAccountListParams()
     {
@@ -30,7 +30,7 @@ class BankAccountListTest extends \PHPUnit_Framework_TestCase
             $count
         );
 
-        $this->assertEquals(self::METHOD, $request->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $request->getMethod());
         $this->assertEquals(self::PATH, $request->getPath());
         $this->assertEquals(
             [

--- a/tests/unit/BulkAnticipation/Request/BulkAnticipationCancelTest.php
+++ b/tests/unit/BulkAnticipation/Request/BulkAnticipationCancelTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTest\BankAccount\Request;
 
 use PagarMe\Sdk\BulkAnticipation\Request\BulkAnticipationCancel;
+use PagarMe\Sdk\Request;
 
 class BulkAnticipationCancelTest extends \PHPUnit_Framework_TestCase
 {
     const PATH         = 'recipients/re_123456/bulk_anticipations/ba_123456/cancel';
     const RECIPIENT_ID = 're_123456';
-    const METHOD       = 'POST';
 
     const ANTICIPATION_ID = 'ba_123456';
 
@@ -34,6 +34,6 @@ class BulkAnticipationCancelTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $bulkAnticipationCancel->getPayload());
         $this->assertEquals(self::PATH, $bulkAnticipationCancel->getPath());
-        $this->assertEquals(self::METHOD, $bulkAnticipationCancel->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $bulkAnticipationCancel->getMethod());
     }
 }

--- a/tests/unit/BulkAnticipation/Request/BulkAnticipationConfirmTest.php
+++ b/tests/unit/BulkAnticipation/Request/BulkAnticipationConfirmTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTest\BankAccount\Request;
 
 use PagarMe\Sdk\BulkAnticipation\Request\BulkAnticipationConfirm;
+use PagarMe\Sdk\Request;
 
 class BulkAnticipationConfirmTest extends \PHPUnit_Framework_TestCase
 {
     const PATH         = 'recipients/re_123456/bulk_anticipations/ba_123456/confirm';
     const RECIPIENT_ID = 're_123456';
-    const METHOD       = 'POST';
 
     const ANTICIPATION_ID = 'ba_123456';
 
@@ -34,6 +34,6 @@ class BulkAnticipationConfirmTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $bulkAnticipationConfirm->getPayload());
         $this->assertEquals(self::PATH, $bulkAnticipationConfirm->getPath());
-        $this->assertEquals(self::METHOD, $bulkAnticipationConfirm->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $bulkAnticipationConfirm->getMethod());
     }
 }

--- a/tests/unit/BulkAnticipation/Request/BulkAnticipationCreateTest.php
+++ b/tests/unit/BulkAnticipation/Request/BulkAnticipationCreateTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTest\BankAccount\Request;
 
 use PagarMe\Sdk\BulkAnticipation\Request\BulkAnticipationCreate;
+use PagarMe\Sdk\Request;
 
 class BulkAnticipationCreateTest extends \PHPUnit_Framework_TestCase
 {
     const PATH         = 'recipients/re_123456/bulk_anticipations';
     const RECIPIENT_ID = 're_123456';
-    const METHOD       = 'POST';
 
     public function bulkAnticipationProvider()
     {
@@ -53,6 +53,6 @@ class BulkAnticipationCreateTest extends \PHPUnit_Framework_TestCase
             $bulkAnticipationCreate->getPayload()
         );
         $this->assertEquals(self::PATH, $bulkAnticipationCreate->getPath());
-        $this->assertEquals(self::METHOD, $bulkAnticipationCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $bulkAnticipationCreate->getMethod());
     }
 }

--- a/tests/unit/BulkAnticipation/Request/BulkAnticipationDeleteTest.php
+++ b/tests/unit/BulkAnticipation/Request/BulkAnticipationDeleteTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTest\BankAccount\Request;
 
 use PagarMe\Sdk\BulkAnticipation\Request\BulkAnticipationDelete;
+use PagarMe\Sdk\Request;
 
 class BulkAnticipationDeleteTest extends \PHPUnit_Framework_TestCase
 {
     const PATH         = 'recipients/re_123456/bulk_anticipations/ba_123456/delete';
     const RECIPIENT_ID = 're_123456';
-    const METHOD       = 'DELETE';
 
     const ANTICIPATION_ID = 'ba_123456';
 
@@ -34,6 +34,6 @@ class BulkAnticipationDeleteTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $bulkAnticipationDelete->getPayload());
         $this->assertEquals(self::PATH, $bulkAnticipationDelete->getPath());
-        $this->assertEquals(self::METHOD, $bulkAnticipationDelete->getMethod());
+        $this->assertEquals(Request::HTTP_DELETE, $bulkAnticipationDelete->getMethod());
     }
 }

--- a/tests/unit/BulkAnticipation/Request/BulkAnticipationLimitsTest.php
+++ b/tests/unit/BulkAnticipation/Request/BulkAnticipationLimitsTest.php
@@ -3,6 +3,7 @@
 namespace PagarMe\SdkTest\BankAccount\Request;
 
 use PagarMe\Sdk\BulkAnticipation\Request\BulkAnticipationLimits;
+use PagarMe\Sdk\Request;
 
 class BulkAnticipationLimitsTest extends \PHPUnit_Framework_TestCase
 {
@@ -10,7 +11,6 @@ class BulkAnticipationLimitsTest extends \PHPUnit_Framework_TestCase
 
     const PATH         = 'recipients/re_123456/bulk_anticipations/limits';
     const RECIPIENT_ID = 're_123456';
-    const METHOD       = 'GET';
 
     public function bulkAnticipationProvider()
     {
@@ -47,6 +47,6 @@ class BulkAnticipationLimitsTest extends \PHPUnit_Framework_TestCase
             $bulkAnticipationLimits->getPayload()
         );
         $this->assertEquals(self::PATH, $bulkAnticipationLimits->getPath());
-        $this->assertEquals(self::METHOD, $bulkAnticipationLimits->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $bulkAnticipationLimits->getMethod());
     }
 }

--- a/tests/unit/BulkAnticipation/Request/BulkAnticipationListTest.php
+++ b/tests/unit/BulkAnticipation/Request/BulkAnticipationListTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTest\BankAccount\Request;
 
 use PagarMe\Sdk\BulkAnticipation\Request\BulkAnticipationList;
+use PagarMe\Sdk\Request;
 
 class BulkAnticipationListTest extends \PHPUnit_Framework_TestCase
 {
     const PATH         = 'recipients/re_123456/bulk_anticipations';
     const RECIPIENT_ID = 're_123456';
-    const METHOD       = 'GET';
 
     public function bulkAnticipationListParams()
     {
@@ -45,6 +45,6 @@ class BulkAnticipationListTest extends \PHPUnit_Framework_TestCase
             $bulkAnticipationList->getPayload()
         );
         $this->assertEquals(self::PATH, $bulkAnticipationList->getPath());
-        $this->assertEquals(self::METHOD, $bulkAnticipationList->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $bulkAnticipationList->getMethod());
     }
 }

--- a/tests/unit/Calculation/Request/CalculateInstallmentsRequestTest.php
+++ b/tests/unit/Calculation/Request/CalculateInstallmentsRequestTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Calculation\Request;
 
 use PagarMe\Sdk\Calculation\Request\CalculateInstallmentsRequest;
+use PagarMe\Sdk\Request;
 
 class CalculateInstallmentsRequestTest extends \PHPUnit_Framework_TestCase
 {
     const PATH   = 'transactions/calculate_installments_amount';
-    const METHOD = 'GET';
 
     /**
      * @test
@@ -44,7 +44,7 @@ class CalculateInstallmentsRequestTest extends \PHPUnit_Framework_TestCase
     {
         $calculateInstallmentsRequest = $this->getCalculateInstallmentsRequest();
 
-        $this->assertEquals(self::METHOD, $calculateInstallmentsRequest->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $calculateInstallmentsRequest->getMethod());
     }
 
     protected function getCalculateInstallmentsRequest()

--- a/tests/unit/Card/Request/CardCreateTest.php
+++ b/tests/unit/Card/Request/CardCreateTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Card\Request;
 
 use PagarMe\Sdk\Card\Request\CardCreate;
+use PagarMe\Sdk\Request;
 
 class CardCreateTest extends \PHPUnit_Framework_TestCase
 {
     const PATH            = 'cards';
-    const METHOD          = 'POST';
     const CARD_NUMBER     = '4539401723324663';
     const CARD_HOLDER     = 'João Silva';
     const CARD_EXPIRATION = '0423';
@@ -58,6 +58,6 @@ class CardCreateTest extends \PHPUnit_Framework_TestCase
             self::CARD_EXPIRATION
         );
 
-        $this->assertEquals(self::METHOD, $cardCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $cardCreate->getMethod());
     }
 }

--- a/tests/unit/Card/Request/CardGetTest.php
+++ b/tests/unit/Card/Request/CardGetTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Card\Request;
 
 use PagarMe\Sdk\Card\Request\CardGet;
+use PagarMe\Sdk\Request;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
     const PATH    = 'cards/card_ci6y37h16wrxsmzyi';
-    const METHOD  = 'GET';
     const CARD_ID = 'card_ci6y37h16wrxsmzyi';
 
     /**
@@ -37,6 +37,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $cardGet = new CardGet(self::CARD_ID);
 
-        $this->assertEquals(self::METHOD, $cardGet->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $cardGet->getMethod());
     }
 }

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest;
 
 use PagarMe\Sdk\Client;
+use PagarMe\Sdk\Request;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
-    const REQUEST_METHOD = 'POST';
     const REQUEST_PATH   = 'test';
     const CONTENT        = 'sample content';
     const API_KEY        = 'myApiKey';
@@ -42,7 +42,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $request->method('getMethod')->willReturn(self::REQUEST_METHOD);
+        $request->method('getMethod')->willReturn(Request::HTTP_POST);
         $request->method('getPath')->willReturn(self::REQUEST_PATH);
         $request->method('getPayload')->willReturn(
             ['content' => self::CONTENT]
@@ -68,7 +68,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $guzzleClientMock->expects($this->once())
             ->method('createRequest')
             ->with(
-                self::REQUEST_METHOD,
+                Request::HTTP_POST,
                 self::REQUEST_PATH,
                 [
                     'json' => [
@@ -97,7 +97,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $request->method('getMethod')->willReturn(self::REQUEST_METHOD);
+        $request->method('getMethod')->willReturn(Request::HTTP_POST);
         $request->method('getPath')->willReturn(self::REQUEST_PATH);
         $request->method('getPayload')->willReturn(
             ['content' => self::CONTENT]
@@ -143,7 +143,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $request->method('getMethod')->willReturn(self::REQUEST_METHOD);
+        $request->method('getMethod')->willReturn(Request::HTTP_POST);
         $request->method('getPath')->willReturn(self::REQUEST_PATH);
         $request->method('getPayload')->willReturn(
             ['content' => self::CONTENT]

--- a/tests/unit/Company/Request/CompanyInfoTest.php
+++ b/tests/unit/Company/Request/CompanyInfoTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Company\Request;
 
 use PagarMe\Sdk\Company\Request\CompanyInfo;
+use PagarMe\Sdk\Request;
 
 class CompanyInfoTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD = 'GET';
     const PATH   = 'company';
 
     /**
@@ -30,7 +30,7 @@ class CompanyInfoTest extends \PHPUnit_Framework_TestCase
         $companyInfo = new CompanyInfo();
 
         $this->assertEquals(
-            self::METHOD,
+            Request::HTTP_GET,
             $companyInfo->getMethod()
         );
     }

--- a/tests/unit/Customer/Request/CustomerCreateTest.php
+++ b/tests/unit/Customer/Request/CustomerCreateTest.php
@@ -4,11 +4,11 @@ namespace PagarMe\SdkTest\Customer\Request;
 
 use PagarMe\Sdk\Customer\Request\CustomerCreate;
 use PagarMe\Sdk\Customer\Customer;
+use PagarMe\Sdk\Request;
 
 class CustomerCreateTest extends \PHPUnit_Framework_TestCase
 {
     const PATH            = 'customers';
-    const METHOD          = 'POST';
 
     const NAME            = 'Eduardo Nascimento';
     const EMAIL           = 'eduardo@eduardo.com';
@@ -106,7 +106,7 @@ class CustomerCreateTest extends \PHPUnit_Framework_TestCase
             null
         );
 
-        $this->assertEquals(self::METHOD, $customerCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $customerCreate->getMethod());
     }
 
     private function getAddressMock()

--- a/tests/unit/Customer/Request/CustomerGetTest.php
+++ b/tests/unit/Customer/Request/CustomerGetTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Customer\Request;
 
 use PagarMe\Sdk\Customer\Request\CustomerGet;
+use PagarMe\Sdk\Request;
 
 class CustomerGetTest extends \PHPUnit_Framework_TestCase
 {
     const PATH        = 'customers/1337';
-    const METHOD      = 'GET';
     const CUSTOMER_ID = '1337';
 
     /**
@@ -35,6 +35,6 @@ class CustomerGetTest extends \PHPUnit_Framework_TestCase
     public function mustMethodBeCorrect()
     {
         $customerGet = new CustomerGet(self::CUSTOMER_ID);
-        $this->assertEquals(self::METHOD, $customerGet->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $customerGet->getMethod());
     }
 }

--- a/tests/unit/Customer/Request/CustomerListTest.php
+++ b/tests/unit/Customer/Request/CustomerListTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Customer\Request;
 
 use PagarMe\Sdk\Customer\Request\CustomerList;
+use PagarMe\Sdk\Request;
 
 class CustomerListTest extends \PHPUnit_Framework_TestCase
 {
     const PATH   = 'customers';
-    const METHOD = 'GET';
     const PAGE   = 7;
     const COUNT  = 42;
 
@@ -42,6 +42,6 @@ class CustomerListTest extends \PHPUnit_Framework_TestCase
     public function mustMethodBeCorrect()
     {
         $customerList = new CustomerList(1, 10);
-        $this->assertEquals(self::METHOD, $customerList->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $customerList->getMethod());
     }
 }

--- a/tests/unit/Payable/Request/PayableGetTest.php
+++ b/tests/unit/Payable/Request/PayableGetTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Payable\Request;
 
 use PagarMe\Sdk\Payable\Request\PayableGet;
+use PagarMe\Sdk\Request;
 
 class PayableGetTest extends \PHPUnit_Framework_TestCase
 {
     const PAYABLE_ID = 123456;
-    const METHOD     = 'GET';
     const PATH       = 'payables/123456';
 
     /**
@@ -18,7 +18,7 @@ class PayableGetTest extends \PHPUnit_Framework_TestCase
         $payableGet = new PayableGet(self::PAYABLE_ID);
 
         $this->assertEquals([], $payableGet->getPayload());
-        $this->assertEquals(self::METHOD, $payableGet->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $payableGet->getMethod());
         $this->assertEquals(self::PATH, $payableGet->getPath());
     }
 }

--- a/tests/unit/Payable/Request/PayableListTest.php
+++ b/tests/unit/Payable/Request/PayableListTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Payable\Request;
 
 use PagarMe\Sdk\Payable\Request\PayableList;
+use PagarMe\Sdk\Request;
 
 class PayableListTest extends \PHPUnit_Framework_TestCase
 {
     const PATH   = 'payables';
-    const METHOD = 'GET';
 
     public function payableListParams()
     {
@@ -28,7 +28,7 @@ class PayableListTest extends \PHPUnit_Framework_TestCase
         $request = new PayableList($page, $count);
 
         $this->assertEquals(self::PATH, $request->getPath());
-        $this->assertEquals(self::METHOD, $request->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $request->getMethod());
         $this->assertEquals(
             [
                 'page'  => $page,

--- a/tests/unit/Plan/Request/PlanCreateTest.php
+++ b/tests/unit/Plan/Request/PlanCreateTest.php
@@ -3,11 +3,12 @@
 namespace PagarMe\SdkTest\Request;
 
 use PagarMe\Sdk\Plan\Request\PlanCreate;
+use PagarMe\Sdk\Request;
 
 class PlanCreateTest extends \PHPUnit_Framework_TestCase
 {
-    const PATH   = 'plans';
-    const METHOD = 'POST';
+    const PATH = 'plans';
+
     /**
      * @test
     **/
@@ -25,7 +26,7 @@ class PlanCreateTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(self::PATH, $request->getPath());
-        $this->assertEquals(self::METHOD, $request->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $request->getMethod());
         $this->assertEquals(
             [
                 'amount'           => 1337,

--- a/tests/unit/Plan/Request/PlanGetTest.php
+++ b/tests/unit/Plan/Request/PlanGetTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Request;
 
 use PagarMe\Sdk\Plan\Request\PlanGet;
+use PagarMe\Sdk\Request;
 
 class PlanGetTest extends \PHPUnit_Framework_TestCase
 {
     const PATH    = 'plans/123';
-    const METHOD  = 'GET';
     const PLAN_ID = '123';
 
     /**
@@ -18,7 +18,7 @@ class PlanGetTest extends \PHPUnit_Framework_TestCase
         $request = new PlanGet(self::PLAN_ID);
 
         $this->assertEquals(self::PATH, $request->getPath());
-        $this->assertEquals(self::METHOD, $request->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $request->getMethod());
         $this->assertEquals(
             [],
             $request->getPayload()

--- a/tests/unit/Plan/Request/PlanListTest.php
+++ b/tests/unit/Plan/Request/PlanListTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Request;
 
 use PagarMe\Sdk\Plan\Request\PlanList;
+use PagarMe\Sdk\Request;
 
 class PlanListTest extends \PHPUnit_Framework_TestCase
 {
     const PATH   = 'plans';
-    const METHOD = 'GET';
 
     public function planListParams()
     {
@@ -28,7 +28,7 @@ class PlanListTest extends \PHPUnit_Framework_TestCase
         $request = new PlanList($page, $count);
 
         $this->assertEquals(self::PATH, $request->getPath());
-        $this->assertEquals(self::METHOD, $request->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $request->getMethod());
         $this->assertEquals(
             [
                 'page'  => $page,

--- a/tests/unit/Plan/Request/PlanUpdateTest.php
+++ b/tests/unit/Plan/Request/PlanUpdateTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Request;
 
 use PagarMe\Sdk\Plan\Request\PlanUpdate;
+use PagarMe\Sdk\Request;
 
 class PlanUpdateTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD  = 'PUT';
-    const PATH    = 'plans/1406';
+    const PATH = 'plans/1406';
 
     const ID              = 1406;
     const AMOUNT          = 1337;
@@ -41,7 +41,7 @@ class PlanUpdateTest extends \PHPUnit_Framework_TestCase
         $request = new PlanUpdate($planMock);
 
         $this->assertEquals(self::PATH, $request->getPath());
-        $this->assertEquals(self::METHOD, $request->getMethod());
+        $this->assertEquals(Request::HTTP_PUT, $request->getMethod());
         $this->assertEquals(
             [
                 'id'              => self::ID,

--- a/tests/unit/Postback/Request/PostbackGetTest.php
+++ b/tests/unit/Postback/Request/PostbackGetTest.php
@@ -3,13 +3,13 @@
 namespace PagarMe\SdkTest\Postback\Request;
 
 use PagarMe\Sdk\Postback\Request\PostbackGet;
+use PagarMe\Sdk\Request;
 
 class PostbackGetTest extends \PHPUnit_Framework_TestCase
 {
     const TRANSACTION_ID = 1234;
     const POSTBACK_ID    = 'po_10000001';
     const PATH           = 'transactions/1234/postbacks/po_10000001';
-    const METHOD         = 'GET';
 
     /**
      * @test
@@ -26,6 +26,6 @@ class PostbackGetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $postbackGet->getPayload());
         $this->assertEquals(self::PATH, $postbackGet->getPath());
-        $this->assertEquals(self::METHOD, $postbackGet->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $postbackGet->getMethod());
     }
 }

--- a/tests/unit/Postback/Request/PostbackListTest.php
+++ b/tests/unit/Postback/Request/PostbackListTest.php
@@ -3,12 +3,13 @@
 namespace PagarMe\SdkTest\Postback\Request;
 
 use PagarMe\Sdk\Postback\Request\PostbackList;
+use PagarMe\Sdk\Request;
 
 class PostbackListTest extends \PHPUnit_Framework_TestCase
 {
     const TRANSACTION_ID = 1234;
     const PATH           = 'transactions/1234/postbacks';
-    const METHOD         = 'GET';
+
 
     /**
      * @test
@@ -25,6 +26,6 @@ class PostbackListTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $postbackList->getPayload());
         $this->assertEquals(self::PATH, $postbackList->getPath());
-        $this->assertEquals(self::METHOD, $postbackList->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $postbackList->getMethod());
     }
 }

--- a/tests/unit/Postback/Request/PostbackRedeliverTest.php
+++ b/tests/unit/Postback/Request/PostbackRedeliverTest.php
@@ -3,13 +3,13 @@
 namespace PagarMe\SdkTest\Postback\Request;
 
 use PagarMe\Sdk\Postback\Request\PostbackRedeliver;
+use PagarMe\Sdk\Request;
 
 class PostbackRedeliverTest extends \PHPUnit_Framework_TestCase
 {
     const TRANSACTION_ID = 1234;
     const POSTBACK_ID    = 'po_10000001';
     const PATH           = 'transactions/1234/postbacks/po_10000001/redeliver';
-    const METHOD         = 'POST';
 
     /**
      * @test
@@ -29,6 +29,6 @@ class PostbackRedeliverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $postbackRedeliver->getPayload());
         $this->assertEquals(self::PATH, $postbackRedeliver->getPath());
-        $this->assertEquals(self::METHOD, $postbackRedeliver->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $postbackRedeliver->getMethod());
     }
 }

--- a/tests/unit/Recipient/Request/RecipientBalanceTest.php
+++ b/tests/unit/Recipient/Request/RecipientBalanceTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTests\Recipient;
 
 use PagarMe\Sdk\Recipient\Request\RecipientBalance;
+use PagarMe\Sdk\Request;
 
 class RecipientBalanceTest extends \PHPUnit_Framework_TestCase
 {
     const ID     = 're_x1y2z3';
     const PATH   = 'recipients/re_x1y2z3/balance';
-    const METHOD = 'GET';
 
     /**
      * @test
@@ -37,7 +37,7 @@ class RecipientBalanceTest extends \PHPUnit_Framework_TestCase
 
         $recipientBalance = new RecipientBalance($recipientMock);
 
-        $this->assertEquals(self::METHOD, $recipientBalance->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $recipientBalance->getMethod());
     }
 
     /**

--- a/tests/unit/Recipient/Request/RecipientCreateTest.php
+++ b/tests/unit/Recipient/Request/RecipientCreateTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTests\Recipient;
 
 use PagarMe\Sdk\Recipient\Request\RecipientCreate;
+use PagarMe\Sdk\Request;
 
 class RecipientCreateTest extends \PHPUnit_Framework_TestCase
 {
     const PATH            = 'recipients';
-    const METHOD          = 'POST';
 
     const BANK_ACCOUNT_ID = 123;
 
@@ -57,7 +57,7 @@ class RecipientCreateTest extends \PHPUnit_Framework_TestCase
             null
         );
 
-        $this->assertEquals(self::METHOD, $recipientCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $recipientCreate->getMethod());
     }
 
     public function recipientParams()

--- a/tests/unit/Recipient/Request/RecipientGetTest.php
+++ b/tests/unit/Recipient/Request/RecipientGetTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTests\Recipient;
 
 use PagarMe\Sdk\Recipient\Request\RecipientGet;
+use PagarMe\Sdk\Request;
 
 class RecipientGetTest extends \PHPUnit_Framework_TestCase
 {
-    const ID              = 're_x1y2z3';
-    const PATH            = 'recipients/re_x1y2z3';
-    const METHOD          = 'GET';
+    const ID   = 're_x1y2z3';
+    const PATH = 'recipients/re_x1y2z3';
 
     /**
      * @test
@@ -27,7 +27,7 @@ class RecipientGetTest extends \PHPUnit_Framework_TestCase
     {
         $recipientGet = new RecipientGet(self::ID);
 
-        $this->assertEquals(self::METHOD, $recipientGet->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $recipientGet->getMethod());
     }
 
     /**

--- a/tests/unit/Recipient/Request/RecipientListTest.php
+++ b/tests/unit/Recipient/Request/RecipientListTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTests\Recipient;
 
 use PagarMe\Sdk\Recipient\Request\RecipientList;
+use PagarMe\Sdk\Request;
 
 class RecipientListTest extends \PHPUnit_Framework_TestCase
 {
-    const PATH            = 'recipients';
-    const METHOD          = 'GET';
+    const PATH = 'recipients';
 
     public function recipientListProvider()
     {
@@ -39,7 +39,7 @@ class RecipientListTest extends \PHPUnit_Framework_TestCase
     {
         $recipientList = new RecipientList($page, $count);
 
-        $this->assertEquals(self::METHOD, $recipientList->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $recipientList->getMethod());
     }
 
     /**

--- a/tests/unit/Recipient/Request/RecipientOperationTest.php
+++ b/tests/unit/Recipient/Request/RecipientOperationTest.php
@@ -3,13 +3,14 @@
 namespace PagarMe\SdkTests\Recipient;
 
 use PagarMe\Sdk\Recipient\Request\RecipientBalanceOperation;
+use PagarMe\Sdk\Request;
 
 class RecipientBalanceOperationTest extends \PHPUnit_Framework_TestCase
 {
     const RECIPIENT_ID = 're_x1y2z3';
     const OPERATION_ID = '123';
     const PATH         = 'recipients/re_x1y2z3/balance/operations/123';
-    const METHOD       = 'GET';
+
 
     /**
      * @test
@@ -44,7 +45,7 @@ class RecipientBalanceOperationTest extends \PHPUnit_Framework_TestCase
             self::OPERATION_ID
         );
 
-        $this->assertEquals(self::METHOD, $recipientBalanceOperation->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $recipientBalanceOperation->getMethod());
     }
 
     /**

--- a/tests/unit/Recipient/Request/RecipientOperationsTest.php
+++ b/tests/unit/Recipient/Request/RecipientOperationsTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTests\Recipient;
 
 use PagarMe\Sdk\Recipient\Request\RecipientBalanceOperations;
+use PagarMe\Sdk\Request;
 
 class RecipientBalanceOperationsTest extends \PHPUnit_Framework_TestCase
 {
     const RECIPIENT_ID = 're_x1y2z3';
     const PATH         = 'recipients/re_x1y2z3/balance/operations';
-    const METHOD       = 'GET';
 
     public function recipientBalanceOperationsMock()
     {
@@ -52,7 +52,7 @@ class RecipientBalanceOperationsTest extends \PHPUnit_Framework_TestCase
             $count
         );
 
-        $this->assertEquals(self::METHOD, $recipientBalanceOperations->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $recipientBalanceOperations->getMethod());
     }
 
 

--- a/tests/unit/Recipient/Request/RecipientUpdateTest.php
+++ b/tests/unit/Recipient/Request/RecipientUpdateTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTests\Recipient;
 
 use PagarMe\Sdk\Recipient\Request\RecipientUpdate;
+use PagarMe\Sdk\Request;
 
 class RecipientUpdateTest extends \PHPUnit_Framework_TestCase
 {
-    const PATH            = 'recipients/re_x1y2z3';
-    const RECIPIENT_ID    = 're_x1y2z3';
-    const METHOD          = 'PUT';
+    const PATH         = 'recipients/re_x1y2z3';
+    const RECIPIENT_ID = 're_x1y2z3';
 
     const BANK_ACCOUNT_ID = 123;
 
@@ -52,7 +52,7 @@ class RecipientUpdateTest extends \PHPUnit_Framework_TestCase
 
         $recipientUpdate = new RecipientUpdate($recipientMock);
 
-        $this->assertEquals(self::METHOD, $recipientUpdate->getMethod());
+        $this->assertEquals(Request::HTTP_PUT, $recipientUpdate->getMethod());
     }
 
     /**

--- a/tests/unit/Search/Request/SearchGetTest.php
+++ b/tests/unit/Search/Request/SearchGetTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Search\Request;
 
 use PagarMe\Sdk\Search\Request\SearchGet;
+use PagarMe\Sdk\Request;
 
 class SearchGetTest extends \PHPUnit_Framework_TestCase
 {
     const PATH   = 'search';
-    const METHOD = 'GET';
     const TYPE   = 'transaction';
 
     /**
@@ -25,7 +25,7 @@ class SearchGetTest extends \PHPUnit_Framework_TestCase
             $searchGet->getPayload()
         );
         $this->assertEquals(self::PATH, $searchGet->getPath());
-        $this->assertEquals(self::METHOD, $searchGet->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $searchGet->getMethod());
     }
 
     private function getQueryParams()

--- a/tests/unit/Subscription/Request/BoletoSubscriptionCreateTest.php
+++ b/tests/unit/Subscription/Request/BoletoSubscriptionCreateTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Subscription\Request;
 
 use PagarMe\Sdk\Subscription\Request\BoletoSubscriptionCreate;
+use PagarMe\Sdk\Request;
 
 class BoletoSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD = 'POST';
     const PATH   = 'subscriptions';
 
     const PLAN_ID             = 123;
@@ -143,7 +143,7 @@ class BoletoSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $boletoSubscriptionCreateRequest->getMethod(),
-            self::METHOD
+            Request::HTTP_POST
         );
     }
 

--- a/tests/unit/Subscription/Request/CardSubscriptionCreateTest.php
+++ b/tests/unit/Subscription/Request/CardSubscriptionCreateTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Subscription\Request;
 
 use PagarMe\Sdk\Subscription\Request\CardSubscriptionCreate;
+use PagarMe\Sdk\Request;
 
 class CardSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD = 'POST';
     const PATH   = 'subscriptions';
 
     const PLAN_ID             = 123;
@@ -155,7 +155,7 @@ class CardSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $cardSubscriptionCreateRequest->getMethod(),
-            self::METHOD
+            Request::HTTP_POST
         );
     }
 

--- a/tests/unit/Subscription/Request/SubscriptionCancelTest.php
+++ b/tests/unit/Subscription/Request/SubscriptionCancelTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Subscription\Request;
 
 use PagarMe\Sdk\Subscription\Request\SubscriptionCancel;
+use PagarMe\Sdk\Request;
 
 class SubscriptionCancelTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD          = 'POST';
     const PATH            = 'subscriptions/123/cancel';
     const SUBSCRIPTION_ID = 123;
 
@@ -32,7 +32,7 @@ class SubscriptionCancelTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $subscriptionCancelRequest->getMethod(),
-            self::METHOD
+            Request::HTTP_POST
         );
     }
 

--- a/tests/unit/Subscription/Request/SubscriptionGetTest.php
+++ b/tests/unit/Subscription/Request/SubscriptionGetTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Subscription\Request;
 
 use PagarMe\Sdk\Subscription\Request\SubscriptionGet;
+use PagarMe\Sdk\Request;
 
 class SubscriptionGetTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD          = 'GET';
     const PATH            = 'subscriptions/123';
     const SUBSCRIPTION_ID = 123;
 
@@ -32,7 +32,7 @@ class SubscriptionGetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $subscriptionGetRequest->getMethod(),
-            self::METHOD
+            Request::HTTP_GET
         );
     }
 

--- a/tests/unit/Subscription/Request/SubscriptionListTest.php
+++ b/tests/unit/Subscription/Request/SubscriptionListTest.php
@@ -3,13 +3,13 @@
 namespace PagarMe\SdkTest\Subscription\Request;
 
 use PagarMe\Sdk\Subscription\Request\SubscriptionList;
+use PagarMe\Sdk\Request;
 
 class SubscriptionListTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD = 'GET';
-    const PATH   = 'subscriptions';
-    const PAGE   = 1;
-    const COUNT  = 10;
+    const PATH  = 'subscriptions';
+    const PAGE  = 1;
+    const COUNT = 10;
 
     public function paginationData()
     {
@@ -40,7 +40,7 @@ class SubscriptionListTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $subscriptionListRequest->getMethod(),
-            self::METHOD
+            Request::HTTP_GET
         );
 
         $this->assertEquals(

--- a/tests/unit/Subscription/Request/SubscriptionTransactionGetTest.php
+++ b/tests/unit/Subscription/Request/SubscriptionTransactionGetTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Subscription\Request;
 
 use PagarMe\Sdk\Subscription\Request\SubscriptionTransactionsGet;
+use PagarMe\Sdk\Request;
 
 class SubscriptionTransactionsGetTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD          = 'GET';
     const PATH            = 'subscriptions/123/transactions';
     const SUBSCRIPTION_ID = 123;
 
@@ -18,9 +18,12 @@ class SubscriptionTransactionsGetTest extends \PHPUnit_Framework_TestCase
         $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
             ->disableOriginalConstructor()
             ->getMock();
+
         $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
 
-        $subscriptionCancelRequest = new SubscriptionTransactionsGet($subscriptionMock);
+        $subscriptionCancelRequest = new SubscriptionTransactionsGet(
+            $subscriptionMock
+        );
 
         $this->assertEquals(
             $subscriptionCancelRequest->getPayload(),
@@ -36,13 +39,14 @@ class SubscriptionTransactionsGetTest extends \PHPUnit_Framework_TestCase
         $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
             ->disableOriginalConstructor()
             ->getMock();
+
         $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
 
         $subscriptionCancelRequest = new SubscriptionTransactionsGet($subscriptionMock);
 
         $this->assertEquals(
             $subscriptionCancelRequest->getMethod(),
-            self::METHOD
+            Request::HTTP_GET
         );
     }
 

--- a/tests/unit/Subscription/Request/SubscriptionUpdateTest.php
+++ b/tests/unit/Subscription/Request/SubscriptionUpdateTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Subscription\Request;
 
 use PagarMe\Sdk\Subscription\Request\SubscriptionUpdate;
+use PagarMe\Sdk\Request;
 
 class SubscriptionUpdateTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD          = 'PUT';
     const PATH            = 'subscriptions/123';
     const SUBSCRIPTION_ID = 123;
 
@@ -93,7 +93,7 @@ class SubscriptionUpdateTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $subscriptionCancelRequest->getMethod(),
-            self::METHOD
+            Request::HTTP_PUT
         );
     }
 

--- a/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
@@ -7,11 +7,11 @@ use PagarMe\Sdk\Transaction\BoletoTransaction;
 use PagarMe\Sdk\SplitRule\SplitRuleCollection;
 use PagarMe\Sdk\SplitRule\SplitRule;
 use PagarMe\Sdk\Recipient\Recipient;
+use PagarMe\Sdk\Request;
 
 class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
 {
     const PATH   = 'transactions';
-    const METHOD = 'POST';
 
     const CARD_ID = 1;
 
@@ -174,7 +174,7 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
 
         $transactionCreate = new BoletoTransactionCreate($transaction);
 
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $transactionCreate->getMethod());
     }
 
     private function createTransaction($expirationDate)

--- a/tests/unit/Transaction/Request/BoletoTransactionRefundTest.php
+++ b/tests/unit/Transaction/Request/BoletoTransactionRefundTest.php
@@ -4,10 +4,10 @@ namespace PagarMe\SdkTest\Transaction\Request;
 
 use PagarMe\Sdk\Transaction\Request\BoletoTransactionRefund;
 use PagarMe\Sdk\Transaction\BoletoTransaction;
+use PagarMe\Sdk\Request;
 
 class BoletoTransactionRefundTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD          = 'POST';
     const PATH            = 'transactions/1337/refund';
     const TRANSACTION_ID  = 1337;
     const BANKACCOUNT_ID  = 12345;
@@ -50,7 +50,7 @@ class BoletoTransactionRefundTest extends \PHPUnit_Framework_TestCase
             $transactionCreate->getPath()
         );
 
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $transactionCreate->getMethod());
     }
 
     /**
@@ -95,7 +95,7 @@ class BoletoTransactionRefundTest extends \PHPUnit_Framework_TestCase
             $transactionCreate->getPath()
         );
 
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $transactionCreate->getMethod());
     }
 
     private function getTransactionMock()

--- a/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
@@ -7,11 +7,11 @@ use PagarMe\Sdk\Transaction\CreditCardTransaction;
 use PagarMe\Sdk\SplitRule\SplitRuleCollection;
 use PagarMe\Sdk\SplitRule\SplitRule;
 use PagarMe\Sdk\Recipient\Recipient;
+use PagarMe\Sdk\Request;
 
 class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
 {
     const PATH   = 'transactions';
-    const METHOD = 'POST';
 
     const CARD_ID   = 1;
     const CARD_HASH = 'FC1mH7XLFU5fjPAzDsP0ogeAQh3qXRpHzkIrgDz64lITBUGwio67zm';
@@ -309,7 +309,7 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
         $transaction =  $this->getTransaction(rand(1, 12), false, null);
         $transactionCreate = new CreditCardTransactionCreate($transaction);
 
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $transactionCreate->getMethod());
     }
 
     private function getTransaction($installments, $capture, $postbackUrl)

--- a/tests/unit/Transaction/Request/CreditCardTransactionRefundTest.php
+++ b/tests/unit/Transaction/Request/CreditCardTransactionRefundTest.php
@@ -4,10 +4,10 @@ namespace PagarMe\SdkTest\Transaction\Request;
 
 use PagarMe\Sdk\Transaction\Request\CreditCardTransactionRefund;
 use PagarMe\Sdk\Transaction\CreditCardTransaction;
+use PagarMe\Sdk\Request;
 
 class CreditCardTransactionRefundTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD         = 'POST';
     const PATH           = 'transactions/1337/refund';
     const TRANSACTION_ID = 1337;
 
@@ -44,7 +44,7 @@ class CreditCardTransactionRefundTest extends \PHPUnit_Framework_TestCase
             $transactionCreate->getPath()
         );
 
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $transactionCreate->getMethod());
     }
 
     private function getTransactionMock()

--- a/tests/unit/Transaction/Request/TransactionCaptureTest.php
+++ b/tests/unit/Transaction/Request/TransactionCaptureTest.php
@@ -4,10 +4,10 @@ namespace PagarMe\SdkTest\Transaction\Request;
 
 use PagarMe\Sdk\Transaction\Request\TransactionCapture;
 use PagarMe\Sdk\Transaction\CreditCardTransaction;
+use PagarMe\Sdk\Request;
 
 class TransactionCaptureTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD = 'POST';
     const PATH   = 'transactions/%s/capture';
 
     public function transactionCaptureProvider()
@@ -37,6 +37,6 @@ class TransactionCaptureTest extends \PHPUnit_Framework_TestCase
             $transactionCreate->getPath()
         );
 
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $transactionCreate->getMethod());
     }
 }

--- a/tests/unit/Transaction/Request/TransactionEventsTest.php
+++ b/tests/unit/Transaction/Request/TransactionEventsTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Transaction\Request;
 
 use PagarMe\Sdk\Transaction\Request\TransactionEvents;
+use PagarMe\Sdk\Request;
 
 class TransactionEventsTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD         = 'GET';
     const PATH           = 'transactions/1337/events';
     const TRANSACTION_ID = 1337;
 
@@ -28,6 +28,6 @@ class TransactionEventsTest extends \PHPUnit_Framework_TestCase
             $transactionCreate->getPayload()
         );
         $this->assertEquals(self::PATH, $transactionCreate->getPath());
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $transactionCreate->getMethod());
     }
 }

--- a/tests/unit/Transaction/Request/TransactionGetTest.php
+++ b/tests/unit/Transaction/Request/TransactionGetTest.php
@@ -4,11 +4,11 @@ namespace PagarMe\SdkTest\Transaction\Request;
 
 use PagarMe\Sdk\Transaction\Request\TransactionGet;
 use PagarMe\Sdk\Transaction\CreditCardTransaction;
+use PagarMe\Sdk\Request;
 
 class TransactionGetTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD = 'GET';
-    const PATH   = 'transactions/1337';
+    const PATH           = 'transactions/1337';
     const TRANSACTION_ID = 1337;
 
     /**
@@ -41,6 +41,6 @@ class TransactionGetTest extends \PHPUnit_Framework_TestCase
     {
         $transactionCreate = new TransactionGet(self::TRANSACTION_ID);
 
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $transactionCreate->getMethod());
     }
 }

--- a/tests/unit/Transaction/Request/TransactionListTest.php
+++ b/tests/unit/Transaction/Request/TransactionListTest.php
@@ -4,11 +4,11 @@ namespace PagarMe\SdkTest\Transaction\Request;
 
 use PagarMe\Sdk\Transaction\Request\TransactionList;
 use PagarMe\Sdk\Transaction\CreditCardTransaction;
+use PagarMe\Sdk\Request;
 
 class TransactionListTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD = 'GET';
-    const PATH   = 'transactions';
+    const PATH = 'transactions';
 
     public function paginationProvider()
     {
@@ -36,8 +36,6 @@ class TransactionListTest extends \PHPUnit_Framework_TestCase
             ],
             $transactionCreate->getPayload()
         );
-        $this->assertEquals(self::PATH, $transactionCreate->getPath());
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
     }
 
     /**
@@ -59,6 +57,6 @@ class TransactionListTest extends \PHPUnit_Framework_TestCase
     {
         $transactionCreate = new TransactionList($page, $items);
 
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $transactionCreate->getMethod());
     }
 }

--- a/tests/unit/Transaction/Request/TransactionPayTest.php
+++ b/tests/unit/Transaction/Request/TransactionPayTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Transaction\Request;
 
 use PagarMe\Sdk\Transaction\Request\TransactionPay;
+use PagarMe\Sdk\Request;
 
 class TransactionPayTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD = 'PUT';
-    const PATH   = 'transactions/1337';
+    const PATH           = 'transactions/1337';
     const TRANSACTION_ID = 1337;
 
     /**
@@ -30,6 +30,6 @@ class TransactionPayTest extends \PHPUnit_Framework_TestCase
             $transactionCreate->getPayload()
         );
         $this->assertEquals(self::PATH, $transactionCreate->getPath());
-        $this->assertEquals(self::METHOD, $transactionCreate->getMethod());
+        $this->assertEquals(Request::HTTP_PUT, $transactionCreate->getMethod());
     }
 }

--- a/tests/unit/Transfer/Request/TransferCancelTest.php
+++ b/tests/unit/Transfer/Request/TransferCancelTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Transfer\Request;
 
 use PagarMe\Sdk\Transfer\Request\TransferCancel;
+use PagarMe\Sdk\Request;
 
 class TransferCancelTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD      = 'POST';
     const PATH        = 'transfers/123/cancel';
     const TRANSFER_ID = '123';
 
@@ -24,7 +24,7 @@ class TransferCancelTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $transferCancel->getPayload());
 
-        $this->assertEquals(self::METHOD, $transferCancel->getMethod());
+        $this->assertEquals(Request::HTTP_POST, $transferCancel->getMethod());
 
         $this->assertEquals(self::PATH, $transferCancel->getPath());
     }

--- a/tests/unit/Transfer/Request/TransferCreateTest.php
+++ b/tests/unit/Transfer/Request/TransferCreateTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Transfer\Request;
 
 use PagarMe\Sdk\Transfer\Request\TransferCreate;
+use PagarMe\Sdk\Request;
 
 class TransferCreateTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD       = 'POST';
     const PATH         = 'transfers';
 
     public function recipientData()
@@ -47,7 +47,7 @@ class TransferCreateTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            self::METHOD,
+            Request::HTTP_POST,
             $transferCreate->getMethod()
         );
 

--- a/tests/unit/Transfer/Request/TransferGetTest.php
+++ b/tests/unit/Transfer/Request/TransferGetTest.php
@@ -3,10 +3,10 @@
 namespace PagarMe\SdkTest\Transfer\Request;
 
 use PagarMe\Sdk\Transfer\Request\TransferGet;
+use PagarMe\Sdk\Request;
 
 class TransferGetTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD      = 'GET';
     const PATH        = 'transfers/123';
     const TRANSFER_ID = '123';
 
@@ -19,7 +19,7 @@ class TransferGetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $transferGet->getPayload());
 
-        $this->assertEquals(self::METHOD, $transferGet->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $transferGet->getMethod());
 
         $this->assertEquals(self::PATH, $transferGet->getPath());
     }

--- a/tests/unit/Transfer/Request/TransferListTest.php
+++ b/tests/unit/Transfer/Request/TransferListTest.php
@@ -3,11 +3,11 @@
 namespace PagarMe\SdkTest\Transfer\Request;
 
 use PagarMe\Sdk\Transfer\Request\TransferList;
+use PagarMe\Sdk\Request;
 
 class TransferListTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD       = 'GET';
-    const PATH         = 'transfers';
+    const PATH = 'transfers';
 
     public function paginationData()
     {
@@ -36,7 +36,7 @@ class TransferListTest extends \PHPUnit_Framework_TestCase
             $transferList->getPayload()
         );
 
-        $this->assertEquals(self::METHOD, $transferList->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $transferList->getMethod());
 
         $this->assertEquals(self::PATH, $transferList->getPath());
     }

--- a/tests/unit/Zipcode/Request/ZipcodeGetTest.php
+++ b/tests/unit/Zipcode/Request/ZipcodeGetTest.php
@@ -3,12 +3,12 @@
 namespace PagarMe\SdkTest\Zipcode\Request;
 
 use PagarMe\Sdk\Zipcode\Request\ZipcodeInfoGet;
+use PagarMe\Sdk\Request;
 
 class ZipcodeInfoGetTest extends \PHPUnit_Framework_TestCase
 {
-    const METHOD      = 'GET';
-    const PATH        = 'zipcodes/01034020';
-    const ZIPCODE     = '01034020';
+    const PATH    = 'zipcodes/01034020';
+    const ZIPCODE = '01034020';
 
     /**
      * @test
@@ -19,7 +19,7 @@ class ZipcodeInfoGetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $zipcodeInfoGet->getPayload());
 
-        $this->assertEquals(self::METHOD, $zipcodeInfoGet->getMethod());
+        $this->assertEquals(Request::HTTP_GET, $zipcodeInfoGet->getMethod());
 
         $this->assertEquals(self::PATH, $zipcodeInfoGet->getPath());
     }


### PR DESCRIPTION
Use constants defined in 'PagarMe\Sdk\Request' isntead of literals on requests and tests