### PR TITLE
Removing deprecated param

### DIFF
--- a/lib/Transaction/Request/BoletoTransactionRefund.php
+++ b/lib/Transaction/Request/BoletoTransactionRefund.php
@@ -16,24 +16,17 @@ class BoletoTransactionRefund implements RequestInterface
      * @var BankAccount
      */
     protected $bankAccount;
-    /**
-     * @var int
-     */
-    protected $amount;
 
     /**
      * @param BoletoTransaction $transaction
      * @param BankAccount $bankAccount
-     * @param int $amount
      */
     public function __construct(
         BoletoTransaction $transaction,
-        BankAccount $bankAccount,
-        $amount
+        BankAccount $bankAccount
     ) {
         $this->transaction = $transaction;
         $this->bankAccount = $bankAccount;
-        $this->amount      = $amount;
     }
 
     /**
@@ -41,10 +34,7 @@ class BoletoTransactionRefund implements RequestInterface
      */
     public function getPayload()
     {
-        return array_merge(
-            ['amount' => $this->amount],
-            $this->getBankAccountData()
-        );
+        return $this->getBankAccountData();
     }
 
     /**

--- a/lib/Transaction/TransactionHandler.php
+++ b/lib/Transaction/TransactionHandler.php
@@ -161,10 +161,9 @@ class TransactionHandler extends AbstractHandler
      */
     public function boletoRefund(
         BoletoTransaction $transaction,
-        BankAccount $bankAccount,
-        $amount = null
+        BankAccount $bankAccount
     ) {
-        $request = new BoletoTransactionRefund($transaction, $bankAccount, $amount);
+        $request = new BoletoTransactionRefund($transaction, $bankAccount);
         $response = $this->client->send($request);
 
         return $this->buildTransaction($response);

--- a/tests/unit/Transaction/Request/BoletoTransactionRefundTest.php
+++ b/tests/unit/Transaction/Request/BoletoTransactionRefundTest.php
@@ -11,7 +11,6 @@ class BoletoTransactionRefundTest extends \PHPUnit_Framework_TestCase
     const PATH            = 'transactions/1337/refund';
     const TRANSACTION_ID  = 1337;
     const BANKACCOUNT_ID  = 12345;
-    const AMOUNT          = 500;
     const BANK_CODE       = 237;
     const AGENCIA         = 1382;
     const AGENCIA_DV      = 0;
@@ -33,13 +32,11 @@ class BoletoTransactionRefundTest extends \PHPUnit_Framework_TestCase
 
         $transactionCreate = new BoletoTransactionRefund(
             $this->getTransactionMock(),
-            $bankAccountMock,
-            self::AMOUNT
+            $bankAccountMock
         );
 
         $this->assertEquals(
             [
-                'amount'          => self::AMOUNT,
                 'bank_account_id' => self::BANKACCOUNT_ID
             ],
             $transactionCreate->getPayload()
@@ -72,13 +69,11 @@ class BoletoTransactionRefundTest extends \PHPUnit_Framework_TestCase
 
         $transactionCreate = new BoletoTransactionRefund(
             $this->getTransactionMock(),
-            $bankAccountMock,
-            self::AMOUNT
+            $bankAccountMock
         );
 
         $this->assertEquals(
             [
-                'amount'          => self::AMOUNT,
                 'bank_code'       => self::BANK_CODE,
                 'agencia'         => self::AGENCIA,
                 'agencia_dv'      => self::AGENCIA_DV,


### PR DESCRIPTION
`amount` is exclusive for credit card refunds.