### PR TITLE
Optional bank account value on transfer

### DIFF
--- a/lib/Transfer/Request/TransferCreate.php
+++ b/lib/Transfer/Request/TransferCreate.php
@@ -4,6 +4,7 @@ namespace PagarMe\Sdk\Transfer\Request;
 
 use PagarMe\Sdk\RequestInterface;
 use PagarMe\Sdk\Recipient\Recipient;
+use PagarMe\Sdk\BankAccount\BankAccount;
 
 class TransferCreate implements RequestInterface
 {
@@ -18,19 +19,23 @@ class TransferCreate implements RequestInterface
     private $recipient;
 
     /**
-     * @var int
+     * @var \PagarMe\Sdk\BankAccount\BankAccount
      */
-    private $bankAccountId;
+    private $bankAccount;
 
     /**
      * @param int $amount
      * @param Recipient $recipient
+     * @param BankAccount $bankAccount Optional. Default value: null.
      */
-    public function __construct($amount, Recipient $recipient, $bankAccountId)
-    {
-        $this->amount        = $amount;
-        $this->recipient     = $recipient;
-        $this->bankAccountId = $bankAccountId;
+    public function __construct(
+        $amount,
+        Recipient $recipient,
+        BankAccount $bankAccount = null
+    ) {
+        $this->amount      = $amount;
+        $this->recipient   = $recipient;
+        $this->bankAccount = $bankAccount;
     }
 
     /**
@@ -38,10 +43,15 @@ class TransferCreate implements RequestInterface
      */
     public function getPayload()
     {
+        $bankAccountId = null;
+        if ($this->bankAccount instanceof BankAccount) {
+            $bankAccountId = $this->bankAccount->getId();
+        }
+
         return [
-            'amount'          =>$this->amount,
-            'recipient_id'    =>$this->recipient->getId(),
-            'bank_account_id' =>$this->bankAccountId
+            'amount'          => $this->amount,
+            'recipient_id'    => $this->recipient->getId(),
+            'bank_account_id' => $bankAccountId
         ];
     }
 

--- a/lib/Transfer/TransferHandler.php
+++ b/lib/Transfer/TransferHandler.php
@@ -13,19 +13,20 @@ use PagarMe\Sdk\Transfer\Request\TransferCancel;
 class TransferHandler extends AbstractHandler
 {
     /**
-     * @param int amount
-     * @param Recipient recipient
-     * @param int id
+     * @param int $amount
+     * @param Recipient $recipient
+     * @param BankAccount $bankAccount Optional. Default: null.
+     * @return Transfer
      */
     public function create(
         $amount,
         Recipient $recipient,
-        $bankAccountId = null
+        BankAccount $bankAccount = null
     ) {
         $request = new TransferCreate(
             $amount,
             $recipient,
-            $bankAccountId
+            $bankAccount
         );
 
         $response = $this->client->send($request);

--- a/tests/acceptance/TransferContext.php
+++ b/tests/acceptance/TransferContext.php
@@ -115,7 +115,7 @@ class TransferContext extends BasicContext
             ->create(
                 $this->amount,
                 $defaultRecipient,
-                $defaultRecipient->getBankAccount()->getId()
+                $defaultRecipient->getBankAccount()
             );
     }
 

--- a/tests/unit/Transfer/Request/TransferCreateTest.php
+++ b/tests/unit/Transfer/Request/TransferCreateTest.php
@@ -28,13 +28,17 @@ class TransferCreateTest extends \PHPUnit_Framework_TestCase
         $recipientMock = $this->getMockBuilder('PagarMe\Sdk\Recipient\Recipient')
             ->disableOriginalConstructor()
             ->getMock();
-
         $recipientMock->method('getId')->willReturn($recipientId);
+
+        $bankAccountMock = $this->getMockBuilder('PagarMe\Sdk\BankAccount\BankAccount')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $bankAccountMock->method('getId')->willReturn($bankAccountId);
 
         $transferCreate = new TransferCreate(
             $amount,
             $recipientMock,
-            $bankAccountId
+            $bankAccountMock
         );
 
         $this->assertEquals(


### PR DESCRIPTION
Use `BankAccount` class instead of scalar value. Same as #94.