### PR TITLE
Fixed get's phpdoc

### DIFF
--- a/lib/Recipient/RecipientHandler.php
+++ b/lib/Recipient/RecipientHandler.php
@@ -71,7 +71,7 @@ class RecipientHandler extends AbstractHandler
     }
 
     /**
-     * @param int $recipientId
+     * @param string $recipientId
      * @param int $count
      * @return Recipient
      */


### PR DESCRIPTION
recipientId was int, changed to string, according to the api's documentation. ref: https://docs.pagar.me/api/#objeto-recipient

PS.: Despite of being just cosmetic, some IDE's, like PHPStorm, relies on these PHPDoc to infer wheter the arguments are correct or not.

@xduh