### PR TITLE
Bugfix boleto properties (boletoUrl and boletoBarcode) do not exists

### DIFF
--- a/lib/Transaction/BoletoTransaction.php
+++ b/lib/Transaction/BoletoTransaction.php
@@ -7,6 +7,16 @@ class BoletoTransaction extends AbstractTransaction
     const PAYMENT_METHOD = 'boleto';
 
     /**
+     * @var string
+     */
+    protected $boletoUrl;
+
+    /**
+     * @var string
+     */
+    protected $boletoBarcode;
+
+    /**
      * @var \DateTime
      */
     protected $boletoExpirationDate;


### PR DESCRIPTION
Com este bugfix consegui fechar uma transação em boleto, no retorno não estava sendo capaz de capturar as propriedades boletoUrl e boletoBarcode referenciadas na issue: #128