### PR TITLE
Update Subscription.php

### DIFF
--- a/lib/Pagarme/Subscription.php
+++ b/lib/Pagarme/Subscription.php
@@ -18,8 +18,11 @@ class PagarMe_Subscription extends PagarMe_TransactionCommon {
 		parent::save();
 	}
 
-	public function getTransactions() {
+	public function getTransactions($params = array()) {
 			$request = new PagarMe_Request(self::getUrl() . '/' . $this->id . '/transactions', 'GET');
+			if(!empty($params)){
+				$request->setParameters($params);
+			}
 			$response = $request->run();
 			$this->transactions = PagarMe_Util::convertToPagarMeObject($response);
 			return $this->transactions;


### PR DESCRIPTION
Alteração que torna possível enviar parametros para o método getTransactions() - para os casos onde paginação pode ser necessária.

Atualmente o método só retorna no máximo 10 resultados, sendo impossível especificar o parametro "page" para obter o restante dos registros, com essa alteração é possível especificar parametros avulsos.