### PR TITLE
Adiciona chamada para considerar o soft_descriptor à uma transação

### DIFF
--- a/lib/Transaction/Request/CreditCardTransactionCreate.php
+++ b/lib/Transaction/Request/CreditCardTransactionCreate.php
@@ -29,7 +29,7 @@ class CreditCardTransactionCreate extends TransactionCreate
             $cardData['card_cvv'] = $this->transaction->getCardCvv();
         }
 
-        return array_merge($basicData, $cardData, $this->getCardInfo());
+        return array_merge($basicData, $cardData, $this->getCardInfo(), $this->getSoftDescriptor());
     }
 
     /**
@@ -44,5 +44,17 @@ class CreditCardTransactionCreate extends TransactionCreate
         if (!is_null($this->transaction->getCardHash())) {
             return ['card_hash' => $this->transaction->getCardHash()];
         }
+    }
+	
+	/**
+     * @return array
+     */
+    private function getSoftDescriptor()
+    {
+        if (!is_null($this->transaction->getSoftDescriptor())) {
+            return ['soft_descriptor' => $this->transaction->getSoftDescriptor()];
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
### Descrição

Ao criar uma transação com cartão de crédito, o payload não considerava o parâmetro soft_descriptor definido no array extra_attributes. 
Desta forma, quando definido pelo usuário o valor nunca era repassado para a API, não produzia efeito.

### Número da Issue

N/A

### Testes Realizados

Fiz algumas transações no modo teste da API e recebi o valor soft_descriptor igual ao definido.

@devdrops 
