### PR TITLE
Enabling metadata when capturing a pre-authorized transaction.

### DIFF
--- a/lib/Transaction/Request/TransactionCapture.php
+++ b/lib/Transaction/Request/TransactionCapture.php
@@ -14,15 +14,21 @@ class TransactionCapture implements RequestInterface
      * @var int
      */
     protected $amount;
+    /**
+     * @var array
+     */
+    protected $metadata;
 
     /**
      * @param PagarMe\Sdk\Transaction\Transaction $transaction
      * @param int $amount
+     * @param array $metadata
      */
-    public function __construct($transaction, $amount)
+    public function __construct($transaction, $amount, $metadata = [])
     {
         $this->transaction = $transaction;
         $this->amount = $amount;
+        $this->metadata = $metadata;
     }
 
     /**
@@ -30,12 +36,17 @@ class TransactionCapture implements RequestInterface
      */
     public function getPayload()
     {
-        if (is_null($this->amount)) {
-            return [];
+        $payload = [];
+
+        if (!is_null($this->amount)) {
+            $payload['amount'] = $this->amount;
         }
-        return [
-            'amount' => $this->amount
-        ];
+
+        if (!empty($this->metadata)) {
+            $payload['metadata'] = $this->metadata;
+        }
+
+        return $payload;
     }
 
     /**

--- a/lib/Transaction/TransactionHandler.php
+++ b/lib/Transaction/TransactionHandler.php
@@ -131,10 +131,15 @@ class TransactionHandler extends AbstractHandler
     /**
      * @param AbstractTransaction $transaction
      * @param int $amount
+     * @param array $metadata
      * @return AbstractTransaction
      */
-    public function capture(AbstractTransaction $transaction, $amount = null)    {
-        $request = new TransactionCapture($transaction, $amount);
+    public function capture(
+        AbstractTransaction $transaction,
+        $amount = null,
+        $metadata = []
+    ) {
+        $request = new TransactionCapture($transaction, $amount, $metadata);
         $response = $this->client->send($request);
 
         return $this->buildTransaction($response);

--- a/tests/unit/Transaction/Request/TransactionCaptureTest.php
+++ b/tests/unit/Transaction/Request/TransactionCaptureTest.php
@@ -10,6 +10,8 @@ class TransactionCaptureTest extends \PHPUnit_Framework_TestCase
 {
     const PATH   = 'transactions/%s/capture';
 
+    private $defaultMetadata = ['foo' => 'bar'];
+
     public function transactionIdProvider()
     {
         return [
@@ -106,5 +108,36 @@ class TransactionCaptureTest extends \PHPUnit_Framework_TestCase
             'PagarMe\Sdk\Transaction\AbstractTransaction'
         )->disableOriginalConstructor()
         ->getMock();
+    }
+
+    public function transactionMetadataProvider()
+    {
+        return [
+            [555, null , ['metadata' => $this->defaultMetadata], $this->defaultMetadata],
+            [273690, 500 , ['amount' => 500, 'metadata' => $this->defaultMetadata], $this->defaultMetadata],
+            [888888, 76500 , ['amount' => 76500, 'metadata' => $this->defaultMetadata], $this->defaultMetadata]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider transactionMetadataProvider
+     */
+    public function payloadMustBeEqualWhenProvidingMetadataAtTheCaptureStep(
+        $transactionId,
+        $amount,
+        $payload,
+        $metadata
+    ) {
+        $transaction = $this->getAbstractTransactionMock();
+
+        $transaction->method('getId')->willReturn($transactionId);
+
+        $transactionCreate = new TransactionCapture($transaction, $amount, $metadata);
+
+        $this->assertEquals(
+            $payload,
+            $transactionCreate->getPayload()
+        );
     }
 }

--- a/tests/unit/Transaction/Request/TransactionCaptureTest.php
+++ b/tests/unit/Transaction/Request/TransactionCaptureTest.php
@@ -113,9 +113,9 @@ class TransactionCaptureTest extends \PHPUnit_Framework_TestCase
     public function transactionMetadataProvider()
     {
         return [
-            [555, null , ['metadata' => $this->defaultMetadata], $this->defaultMetadata],
-            [273690, 500 , ['amount' => 500, 'metadata' => $this->defaultMetadata], $this->defaultMetadata],
-            [888888, 76500 , ['amount' => 76500, 'metadata' => $this->defaultMetadata], $this->defaultMetadata]
+            [null, $this->defaultMetadata, ['metadata' => $this->defaultMetadata]],
+            [500 , $this->defaultMetadata, ['amount' => 500, 'metadata' => $this->defaultMetadata]],
+            [76500, $this->defaultMetadata, ['amount' => 76500, 'metadata' => $this->defaultMetadata]]
         ];
     }
 
@@ -124,19 +124,18 @@ class TransactionCaptureTest extends \PHPUnit_Framework_TestCase
      * @dataProvider transactionMetadataProvider
      */
     public function payloadMustBeEqualWhenProvidingMetadataAtTheCaptureStep(
-        $transactionId,
         $amount,
-        $payload,
-        $metadata
+        $metadata,
+        $expectedPayload
     ) {
-        $transaction = $this->getAbstractTransactionMock();
-
-        $transaction->method('getId')->willReturn($transactionId);
-
-        $transactionCreate = new TransactionCapture($transaction, $amount, $metadata);
+        $transactionCreate = new TransactionCapture(
+            $this->getAbstractTransactionMock(),
+            $amount,
+            $metadata
+        );
 
         $this->assertEquals(
-            $payload,
+            $expectedPayload,
             $transactionCreate->getPayload()
         );
     }


### PR DESCRIPTION
### Descrição

Permite adicionar metadata no ato de captura de uma transação.

### Número da Issue

#157

### Testes Realizados

- Testes manuais
- Testes unitários
