### PR TITLE
Headers: Permitir que informações possam ser passadas no header das requisições feitas pela SDK.

### DIFF
--- a/lib/PagarMe.php
+++ b/lib/PagarMe.php
@@ -129,12 +129,16 @@ class PagarMe
      * @param string $apiKey
      * @param int|null $timeout
      */
-    public function __construct($apiKey, $timeout = null)
-    {
+    public function __construct(
+        $apiKey,
+        $timeout = null,
+        $headers = []
+    ) {
         $this->client = new Client(
             new GuzzleClient(
                 [
-                    'base_url' => 'https://api.pagar.me/1/'
+                    'base_url' => 'https://api.pagar.me/1/',
+                    'headers' => $headers
                 ]
             ),
             $apiKey,

--- a/lib/PagarMe.php
+++ b/lib/PagarMe.php
@@ -138,7 +138,9 @@ class PagarMe
             new GuzzleClient(
                 [
                     'base_url' => 'https://api.pagar.me/1/',
-                    'headers' => $headers
+                    'defaults' => [
+                        'headers' => $headers
+                    ]
                 ]
             ),
             $apiKey,


### PR DESCRIPTION
## Contexto

Permite que seja possível passar informações no header das requisições feitas pela SDK.

## Passos para reproduzir

Crie uma instância de `PagarMe\Sdk\PagarMe` passando um array de chave e valor como terceiro parâmetro do construtor, contendo as informações que devam ser passadas no header e faça o uso de métodos do SDK.

## Resultado esperado

As informações passadas no terceiro parâmetro deveriam ser enviadas em todas as requisições.

## Resultado atual

Atualmente não é possível passar o terceiro parâmetro `$headers`.