### PR TITLE
Added support to adding a Card by its hash (pagarme/pagarme-php#168)

### DIFF
--- a/lib/Card/CardHandler.php
+++ b/lib/Card/CardHandler.php
@@ -3,6 +3,7 @@
 namespace PagarMe\Sdk\Card;
 
 use PagarMe\Sdk\AbstractHandler;
+use PagarMe\Sdk\Card\Request\CardCreateFromHash;
 use PagarMe\Sdk\Client;
 use PagarMe\Sdk\Card\Card;
 use PagarMe\Sdk\Card\Request\CardCreate;
@@ -30,6 +31,19 @@ class CardHandler extends AbstractHandler
 
         return $this->buildCard($response);
     }
+
+	/**
+	 * @param string $cardHash
+	 * @return Card
+	 */
+	public function createFromHash($cardHash)
+	{
+		$request = new CardCreateFromHash($cardHash);
+
+		$response = $this->client->send($request);
+
+		return $this->buildCard($response);
+	}
 
     /**
      * @param int $cardId

--- a/lib/Card/Request/CardCreateFromHash.php
+++ b/lib/Card/Request/CardCreateFromHash.php
@@ -16,7 +16,7 @@ class CardCreateFromHash implements RequestInterface
      */
     public function __construct($cardHash)
     {
-        $this->cardHash         = $cardHash;
+        $this->cardHash = $cardHash;
     }
 
     /**
@@ -25,7 +25,7 @@ class CardCreateFromHash implements RequestInterface
     public function getPayload()
     {
         return [
-            'card_hash'          => $this->cardHash
+            'card_hash' => $this->cardHash
         ];
     }
 

--- a/lib/Card/Request/CardCreateFromHash.php
+++ b/lib/Card/Request/CardCreateFromHash.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PagarMe\Sdk\Card\Request;
+
+use PagarMe\Sdk\RequestInterface;
+
+class CardCreateFromHash implements RequestInterface
+{
+    /**
+     * @var string
+     */
+    private $cardHash;
+
+    /**
+     * @param string $cardHash
+     */
+    public function __construct($cardHash)
+    {
+        $this->cardHash         = $cardHash;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPayload()
+    {
+        return [
+            'card_hash'          => $this->cardHash
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return 'cards';
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return self::HTTP_POST;
+    }
+}

--- a/tests/unit/Card/Request/CardCreateFromHashTest.php
+++ b/tests/unit/Card/Request/CardCreateFromHashTest.php
@@ -7,7 +7,7 @@ use PagarMe\Sdk\RequestInterface;
 
 class CardCreateFromHashTest extends \PHPUnit_Framework_TestCase
 {
-    const PATH            = 'cards';
+    const PATH          = 'cards';
     const CARD_HASH     = 'test_transaction_e8Ij0oYalvjTEO17IHqKxNQcigKrYj';
 
     /**

--- a/tests/unit/Card/Request/CardCreateFromHashTest.php
+++ b/tests/unit/Card/Request/CardCreateFromHashTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PagarMe\SdkTest\Card\Request;
+
+use PagarMe\Sdk\Card\Request\CardCreateFromHash;
+use PagarMe\Sdk\RequestInterface;
+
+class CardCreateFromHashTest extends \PHPUnit_Framework_TestCase
+{
+    const PATH            = 'cards';
+    const CARD_HASH     = 'test_transaction_e8Ij0oYalvjTEO17IHqKxNQcigKrYj';
+
+    /**
+     * @test
+     */
+    public function mustPayloadBeCorrect()
+    {
+        $cardCreate = new CardCreateFromHash(self::CARD_HASH);
+
+        $this->assertEquals(['card_hash' => self::CARD_HASH], $cardCreate->getPayload());
+    }
+
+    /**
+     * @test
+     */
+    public function mustPathBeCorrect()
+    {
+        $cardCreate = new CardCreateFromHash(self::CARD_HASH);
+
+        $this->assertEquals(self::PATH, $cardCreate->getPath());
+    }
+
+    /**
+     * @test
+     */
+    public function mustMethodBeCorrect()
+    {
+        $cardCreate = new CardCreateFromHash(self::CARD_HASH);
+
+        $this->assertEquals(RequestInterface::HTTP_POST, $cardCreate->getMethod());
+    }
+}


### PR DESCRIPTION
### Descrição

Adiciona o suporte à adição de cartões através de um `card_hash` gerado pela [Pagarme.js](https://github.com/pagarme/pagarme-js)

### Número da Issue

pagarme/pagarme-php#168

### Testes Realizados

Criado teste unitário `lib/tests/unit/Card/Request/CardCreateFromHashRequest.php`.
Feito teste funcional utilizando a Pagarme.js, disponível no gist: https://gist.github.com/DfKimera/6312e8d65684b78e501d6e41d60fdbf4

Testes feitos com PHP 7.0.2 no macOS Sierra 10.12.4. Não contém código passível de incompatibilidade.

### Review
@xduh 