### PR TITLE
Fix issue #177

### DIFF
--- a/lib/Subscription/Request/SubscriptionCreate.php
+++ b/lib/Subscription/Request/SubscriptionCreate.php
@@ -56,7 +56,7 @@ abstract class SubscriptionCreate implements RequestInterface
      */
     public function getPayload()
     {
-        return [
+        $payload = [
             'plan_id'        => $this->plan->getId(),
             'payment_method' => $this->paymentMethod,
             'metadata'       => $this->metadata,
@@ -64,13 +64,21 @@ abstract class SubscriptionCreate implements RequestInterface
                 'name'            => $this->customer->getName(),
                 'email'           => $this->customer->getEmail(),
                 'document_number' => $this->customer->getDocumentNumber(),
-                'address'         => $this->getAddresssData(),
-                'phone'           => $this->getPhoneData(),
                 'born_at'         => $this->customer->getBornAt(),
                 'gender'          => $this->customer->getGender()
             ],
             'postback_url' => $this->postbackUrl
         ];
+
+        if (!is_null($this->customer->getAddress())) {
+            $payload['customer']['address'] = $this->getAddresssData();
+        }
+
+        if (!is_null($this->customer->getPhone())) {
+            $payload['customer']['phone'] = $this->getPhoneData();
+        }
+
+        return $payload;
     }
 
     /**

--- a/tests/unit/Subscription/Request/BoletoSubscriptionCreateTest.php
+++ b/tests/unit/Subscription/Request/BoletoSubscriptionCreateTest.php
@@ -27,28 +27,56 @@ class BoletoSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
     const ADDRESS_STREETNUMBER = '123';
     const ADDRESS_NEIGHBORHOOD = 'Centro';
     const ADDRESS_ZIPCODE      = '01034020';
-    /**
-     * @test
-     */
-    public function mustPayloadBeCorrect()
+
+    private function getConfiguredCustomerGenericMockForPayloadTest()
     {
-        $planMock = $this->getMockBuilder('PagarMe\Sdk\Plan\Plan')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $planMock->method('getId')->willReturn(self::PLAN_ID);
-
-
         $customerMock = $this->getMockBuilder('PagarMe\Sdk\Customer\Customer')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $phoneMock = $this->getMockBuilder('PagarMe\Sdk\Customer\Phone')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $customerMock->method('getName')
+            ->willReturn(self::CUSTOMER_NAME);
+        $customerMock->method('getEmail')
+            ->willReturn(self::CUSTOMER_EMAIL);
+        $customerMock->method('getDocumentNumber')
+            ->willReturn(self::CUSTOMER_DOCUMENTNUMBER);
+        $customerMock->method('getBornAt')
+            ->willReturn(self::CUSTOMER_BORN_AT);
+        $customerMock->method('getGender')
+            ->willReturn(self::CUSTOMER_GENDER);
 
-        $phoneMock->method('getDdd')->willReturn(self::PHONE_DDD);
-        $phoneMock->method('getNumber')->willReturn(self::PHONE_NUMBER);
+        return $customerMock;
+    }
 
+    private function getConfiguredCustomerWithoutAddressAndPhoneMockForPayloadTest()
+    {
+        $customerMock = $this->getConfiguredCustomerGenericMockForPayloadTest();
+
+        $customerMock->method('getAddress')
+            ->willReturn(null);
+        $customerMock->method('getPhone')
+            ->willReturn(null);
+
+        return $customerMock;
+    }
+
+    private function getConfiguredCustomerMockForPayloadTest()
+    {
+        $addressMock = $this->getConfiguredAddressMockForPayloadTest();
+        $phoneMock = $this->getConfiguredPhoneMockForPayloadTest();
+
+        $customerMock = $this->getConfiguredCustomerGenericMockForPayloadTest();
+
+        $customerMock->method('getAddress')
+            ->willReturn($addressMock);
+        $customerMock->method('getPhone')
+            ->willReturn($phoneMock);
+
+        return $customerMock;
+    }
+
+    private function getConfiguredAddressMockForPayloadTest()
+    {
         $addressMock = $this->getMockBuilder('PagarMe\Sdk\Customer\Address')
             ->disableOriginalConstructor()
             ->getMock();
@@ -62,20 +90,67 @@ class BoletoSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
         $addressMock->method('getZipcode')
             ->willReturn(self::ADDRESS_ZIPCODE);
 
-        $customerMock->method('getName')
-            ->willReturn(self::CUSTOMER_NAME);
-        $customerMock->method('getEmail')
-            ->willReturn(self::CUSTOMER_EMAIL);
-        $customerMock->method('getDocumentNumber')
-            ->willReturn(self::CUSTOMER_DOCUMENTNUMBER);
-        $customerMock->method('getBornAt')
-            ->willReturn(self::CUSTOMER_BORN_AT);
-        $customerMock->method('getGender')
-            ->willReturn(self::CUSTOMER_GENDER);
-        $customerMock->method('getAddress')
-            ->willReturn($addressMock);
-        $customerMock->method('getPhone')
-            ->willReturn($phoneMock);
+        return $addressMock;
+    }
+
+    private function getConfiguredPhoneMockForPayloadTest()
+    {
+        $phoneMock = $this->getMockBuilder('PagarMe\Sdk\Customer\Phone')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $phoneMock->method('getDdd')->willReturn(self::PHONE_DDD);
+        $phoneMock->method('getNumber')->willReturn(self::PHONE_NUMBER);
+
+        return $phoneMock;
+    }
+
+    private function getDefaultPayload()
+    {
+        return [
+            'plan_id'        => self::PLAN_ID,
+            'payment_method' => self::PLAN_PAYMENT_METHOD,
+            'metadata'       => $this->planMetadata(),
+            'customer'       => [
+                'name'            => self::CUSTOMER_NAME,
+                'email'           => self::CUSTOMER_EMAIL,
+                'document_number' => self::CUSTOMER_DOCUMENTNUMBER,
+                'address'         => [
+                    'street'        => self::ADDRESS_STREET,
+                    'street_number' => self::ADDRESS_STREETNUMBER,
+                    'neighborhood'  => self::ADDRESS_NEIGHBORHOOD,
+                    'zipcode'       => self::ADDRESS_ZIPCODE
+                ],
+                'phone'           => [
+                    'ddd'    => self::PHONE_DDD,
+                    'number' => self::PHONE_NUMBER
+                ],
+                'born_at'         => self::CUSTOMER_BORN_AT,
+                'gender'          => self::CUSTOMER_GENDER
+            ],
+            'postback_url' => self::POSTBACK_URL
+        ];
+    }
+
+    private function getDefaultPayloadWithoutAddressAndPhone()
+    {
+        $payload = $this->getDefaultPayload();
+        unset($payload['customer']['address'], $payload['customer']['phone']);
+        return $payload;
+    }
+
+    /**
+     * @test
+     */
+    public function mustPayloadBeCorrect()
+    {
+        $planMock = $this->getMockBuilder('PagarMe\Sdk\Plan\Plan')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $planMock->method('getId')->willReturn(self::PLAN_ID);
+
+
+        $customerMock = $this->getConfiguredCustomerMockForPayloadTest();
 
         $boletoSubscriptionCreateRequest = new BoletoSubscriptionCreate(
             $planMock,
@@ -87,29 +162,34 @@ class BoletoSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $boletoSubscriptionCreateRequest->getPayload(),
-            [
-                'plan_id'        => self::PLAN_ID,
-                'payment_method' => self::PLAN_PAYMENT_METHOD,
-                'metadata'       => $this->planMetadata(),
-                'customer'       => [
-                    'name'            => self::CUSTOMER_NAME,
-                    'email'           => self::CUSTOMER_EMAIL,
-                    'document_number' => self::CUSTOMER_DOCUMENTNUMBER,
-                    'address'         => [
-                        'street'        => self::ADDRESS_STREET,
-                        'street_number' => self::ADDRESS_STREETNUMBER,
-                        'neighborhood'  => self::ADDRESS_NEIGHBORHOOD,
-                        'zipcode'       => self::ADDRESS_ZIPCODE
-                    ],
-                    'phone'           => [
-                        'ddd'    => self::PHONE_DDD,
-                        'number' => self::PHONE_NUMBER
-                    ],
-                    'born_at'         => self::CUSTOMER_BORN_AT,
-                    'gender'          => self::CUSTOMER_GENDER
-                ],
-                'postback_url' => self::POSTBACK_URL
-            ]
+            $this->getDefaultPayload()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mustPayloadWithoutAddressAndPhoneBeCorrect()
+    {
+        $planMock = $this->getMockBuilder('PagarMe\Sdk\Plan\Plan')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $planMock->method('getId')->willReturn(self::PLAN_ID);
+
+
+        $customerMock = $this->getConfiguredCustomerWithoutAddressAndPhoneMockForPayloadTest();
+
+        $boletoSubscriptionCreateRequest = new BoletoSubscriptionCreate(
+            $planMock,
+            $customerMock,
+            self::POSTBACK_URL,
+            $this->planMetadata(),
+            []
+        );
+
+        $this->assertEquals(
+            $boletoSubscriptionCreateRequest->getPayload(),
+            $this->getDefaultPayloadWithoutAddressAndPhone()
         );
     }
 

--- a/tests/unit/Subscription/Request/CardSubscriptionCreateTest.php
+++ b/tests/unit/Subscription/Request/CardSubscriptionCreateTest.php
@@ -41,11 +41,8 @@ class CardSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
         return $planMock;
     }
 
-    private function getConfiguredCustomerMockForPayloadTest()
+    private function getConfiguredCustomerGenericMockForPayloadTest()
     {
-        $addressMock = $this->getConfiguredAddressMockForPayloadTest();
-        $phoneMock = $this->getConfiguredPhoneMockForPayloadTest();
-
         $customerMock = $this->getMockBuilder('PagarMe\Sdk\Customer\Customer')
             ->disableOriginalConstructor()
             ->getMock();
@@ -60,6 +57,29 @@ class CardSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
             ->willReturn(self::CUSTOMER_BORN_AT);
         $customerMock->method('getGender')
             ->willReturn(self::CUSTOMER_GENDER);
+
+        return $customerMock;
+    }
+
+    private function getConfiguredCustomerWithoutAddressAndPhoneMockForPayloadTest()
+    {
+        $customerMock = $this->getConfiguredCustomerGenericMockForPayloadTest();
+
+        $customerMock->method('getAddress')
+            ->willReturn(null);
+        $customerMock->method('getPhone')
+            ->willReturn(null);
+
+        return $customerMock;
+    }
+
+    private function getConfiguredCustomerMockForPayloadTest()
+    {
+        $addressMock = $this->getConfiguredAddressMockForPayloadTest();
+        $phoneMock = $this->getConfiguredPhoneMockForPayloadTest();
+
+        $customerMock = $this->getConfiguredCustomerGenericMockForPayloadTest();
+
         $customerMock->method('getAddress')
             ->willReturn($addressMock);
         $customerMock->method('getPhone')
@@ -125,6 +145,13 @@ class CardSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
+    private function getExpectedPayloadWithoutAddressAndPhone()
+    {
+        $payload = $this->getExpectedPayloadWithCardId();
+        unset($payload['customer']['address'], $payload['customer']['phone']);
+        return $payload;
+    }
+
     private function getExpectedPayloadWithCardId()
     {
         return array_merge(
@@ -166,6 +193,34 @@ class CardSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             $cardSubscriptionCreateRequest->getPayload(),
             $this->getExpectedPayloadWithCardId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mustPayloadBeCorrectWithoutAddressAndPhone()
+    {
+        $planMock = $this->getConfiguredPlanMockForPayloadTest();
+
+        $cardMock = $this->getMockBuilder('PagarMe\Sdk\Card\Card')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $cardMock->method('getId')->willReturn(self::CARD_ID);
+
+        $customerMock = $this->getConfiguredCustomerWithoutAddressAndPhoneMockForPayloadTest();
+
+        $cardSubscriptionCreateRequest = new CardSubscriptionCreate(
+            $planMock,
+            $cardMock,
+            $customerMock,
+            self::POSTBACK_URL,
+            $this->planMetadata()
+        );
+
+        $this->assertEquals(
+            $cardSubscriptionCreateRequest->getPayload(),
+            $this->getExpectedPayloadWithoutAddressAndPhone()
         );
     }
 


### PR DESCRIPTION
### Descrição

Era obrigatório a população dos objetos Address e Phone para criar uma assinatura, mas pela doc da API esse preenchimento somente é necessário quando for usar Antifraude, onde no caso de assinaturas não é utilizado, com isso a população desses objetos são opcionais.

### Número da Issue

#177 

### Testes Realizados

Foi criado mais 2 testes para testar a assinatura por Boleto e Cartão quando não se tem os obejtos Address and Phone populados. Com isso houve necessidade de refatorar os testes para reutilização dos métodos

@xduh @devdrops 
