### PR TITLE
Correções para DELETE /bulk_anticipations/

### DIFF
--- a/lib/BulkAnticipation/BulkAnticipationHandler.php
+++ b/lib/BulkAnticipation/BulkAnticipationHandler.php
@@ -101,9 +101,7 @@ class BulkAnticipationHandler extends AbstractHandler
     ) {
         $request = new BulkAnticipationDelete($recipient, $bulkAnticipation);
 
-        $response = $this->client->send($request);
-
-        return $this->buildBulkAnticipation($response);
+        return $this->client->send($request);
     }
 
     /**

--- a/lib/BulkAnticipation/Request/BulkAnticipationDelete.php
+++ b/lib/BulkAnticipation/Request/BulkAnticipationDelete.php
@@ -51,7 +51,7 @@ class BulkAnticipationDelete implements RequestInterface
     public function getPath()
     {
         return sprintf(
-            'recipients/%s/bulk_anticipations/%s/delete',
+            'recipients/%s/bulk_anticipations/%s/',
             $this->recipient->getId(),
             $this->bulkAnticipation->getId()
         );

--- a/tests/acceptance/BulkAnticipationContext.php
+++ b/tests/acceptance/BulkAnticipationContext.php
@@ -105,4 +105,40 @@ class BulkAnticipationContext extends BasicContext
 
         assertEquals($this->anticipation->getStatus(), $this->expectedStatus);
     }
+
+    /**
+     * @Then when I delete the previously created Anticipation
+     */
+    public function iDeleteThePreviouslyCreatedAnticipation()
+    {
+        assertEquals(3, $this->countAnticipations());
+
+        $result = self::getPagarMe()
+            ->bulkAnticipation()
+            ->delete(
+                $this->recipient,
+                $this->anticipation
+            );
+
+        assertEquals([], $result);
+    }
+
+    /**
+     * @Then the Anticipation should no longer exist
+     */
+    public function theAnticipationShouldNoLongerExist()
+    {
+        assertEquals(2, $this->countAnticipations());
+    }
+
+    private function countAnticipations()
+    {
+        return count(
+            self::getPagarMe()
+                ->bulkAnticipation()
+                ->getList(
+                    $this->recipient
+                )
+        );
+    }
 }

--- a/tests/acceptance/features/bulk_anticipation.feature
+++ b/tests/acceptance/features/bulk_anticipation.feature
@@ -13,3 +13,14 @@ Feature: Bulk Anticipation
     | payment_date  | timeframe | requested_amount | build |
     | +5 days       | start     | 1000             | true  |
     | +6 days       | start     | 1000             | false |
+
+  Scenario Outline: Deleting Bulk Anticipation
+    Given a recipient with anticipatable volume
+    And company has paid transaction with "<requested_amount>"
+    When register a anticipation with "<payment_date>", "<timeframe>", "<requested_amount>", "<build>"
+    Then a anticipation must be created
+    And when I delete the previously created Anticipation
+    Then the Anticipation should no longer exist
+    Examples:
+    | payment_date  | timeframe | requested_amount | build |
+    | +5 days       | start     | 1000             | true  |

--- a/tests/unit/BulkAnticipation/Request/BulkAnticipationDeleteTest.php
+++ b/tests/unit/BulkAnticipation/Request/BulkAnticipationDeleteTest.php
@@ -7,7 +7,7 @@ use PagarMe\Sdk\RequestInterface;
 
 class BulkAnticipationDeleteTest extends \PHPUnit_Framework_TestCase
 {
-    const PATH         = 'recipients/re_123456/bulk_anticipations/ba_123456/delete';
+    const PATH         = 'recipients/re_123456/bulk_anticipations/ba_123456/';
     const RECIPIENT_ID = 're_123456';
 
     const ANTICIPATION_ID = 'ba_123456';


### PR DESCRIPTION
### Descrição

Corrige o uso para excluir Bulk Anticipations.

**Importante:** a aceitação deste PR exige edição na Wiki.

### Número da Issue

#149

### Testes Realizados

Adição de testes de aceitação.
