### PR TITLE
V3 add charge remainder split rule

### DIFF
--- a/lib/SplitRule/SplitRule.php
+++ b/lib/SplitRule/SplitRule.php
@@ -26,6 +26,10 @@ class SplitRule
     /**
      * @var bool
      */
+    private $chargeRemainder;
+    /**
+     * @var bool
+     */
     private $liable;
     /**
      * @var int
@@ -86,6 +90,15 @@ class SplitRule
     public function getChargeProcessingFee()
     {
         return $this->chargeProcessingFee;
+    }
+
+    /**
+     * @return bool
+     * @codeCoverageIgnore
+     */
+    public function getChargeRemainder()
+    {
+        return $this->chargeRemainder;
     }
 
     /**

--- a/lib/SplitRule/SplitRuleHandler.php
+++ b/lib/SplitRule/SplitRuleHandler.php
@@ -6,7 +6,6 @@ use PagarMe\Sdk\Recipient\Recipient;
 
 class SplitRuleHandler
 {
-
     /**
      * @param int $value
      * @param Recipient $recipient

--- a/lib/SplitRule/SplitRuleHandler.php
+++ b/lib/SplitRule/SplitRuleHandler.php
@@ -6,6 +6,7 @@ use PagarMe\Sdk\Recipient\Recipient;
 
 class SplitRuleHandler
 {
+
     /**
      * @param int $value
      * @param Recipient $recipient

--- a/lib/SplitRule/SplitRuleHandler.php
+++ b/lib/SplitRule/SplitRuleHandler.php
@@ -12,13 +12,15 @@ class SplitRuleHandler
      * @param Recipient $recipient
      * @param bool $liable
      * @param bool $chargeProcessingFee
+     * @param bool $chargeRemainder
      * @return SplitRule
      */
     public function monetaryRule(
         $value,
         Recipient $recipient,
         $liable = null,
-        $chargeProcessingFee = null
+        $chargeProcessingFee = null,
+        $chargeRemainder = null
     ) {
         return new SplitRule(
             [
@@ -26,6 +28,7 @@ class SplitRuleHandler
                 'recipient'           => $recipient,
                 'liable'              => $liable,
                 'chargeProcessingFee' => $chargeProcessingFee,
+                'chargeRemainder'     => $chargeRemainder,
             ]
         );
     }
@@ -35,13 +38,15 @@ class SplitRuleHandler
      * @param Recipient $recipient
      * @param bool $liable
      * @param bool $chargeProcessingFee
+     * @param bool $chargeRemainder
      * @return SplitRule
      */
     public function percentageRule(
         $value,
         Recipient $recipient,
         $liable = null,
-        $chargeProcessingFee = null
+        $chargeProcessingFee = null,
+        $chargeRemainder = null
     ) {
         return new SplitRule(
             [
@@ -49,6 +54,7 @@ class SplitRuleHandler
                 'recipient'           => $recipient,
                 'liable'              => $liable,
                 'chargeProcessingFee' => $chargeProcessingFee,
+                'chargeRemainder'     => $chargeRemainder,
             ]
         );
     }

--- a/lib/Transaction/CreditCardTransaction.php
+++ b/lib/Transaction/CreditCardTransaction.php
@@ -7,7 +7,7 @@ class CreditCardTransaction extends AbstractTransaction
     const PAYMENT_METHOD = 'credit_card';
 
     /**
-     * @var PagarMe\Sdk\Card\Card
+     * @var \PagarMe\Sdk\Card\Card
      */
     protected $card;
 

--- a/lib/Transaction/TransactionHandler.php
+++ b/lib/Transaction/TransactionHandler.php
@@ -25,12 +25,12 @@ class TransactionHandler extends AbstractHandler
 
     /**
      * @param int $amount
-     * @param PagarMe\Sdk\Card\Card $card
-     * @param PagarMe\Sdk\Customer\Customer $customer
+     * @param \PagarMe\Sdk\Card\Card $card
+     * @param \PagarMe\Sdk\Customer\Customer $customer
      * @param int $installments
      * @param boolean $capture
      * @param string $postBackUrl
-     * @param array $metaData
+     * @param array $metadata
      * @param array $extraAttributes
      * @return CreditCardTransaction
      */
@@ -66,8 +66,9 @@ class TransactionHandler extends AbstractHandler
 
     /**
      * @param int $amount
-     * @param PagarMe\Sdk\Customer\Customer $customer
+     * @param \PagarMe\Sdk\Customer\Customer $customer
      * @param string $postBackUrl
+     * @param mixed $metadata
      * @param array $extraAttributes
      * @return BoletoTransaction
      */
@@ -160,7 +161,7 @@ class TransactionHandler extends AbstractHandler
 
     /**
      * @param BoletoTransaction $transaction
-     * @param PagarMe\Sdk\BankAccount\BankAccount $bankAccount
+     * @param \PagarMe\Sdk\BankAccount\BankAccount $bankAccount
      * @param int @amount
      * @return BoletoTransaction
      */

--- a/tests/acceptance/SplitRuleContext.php
+++ b/tests/acceptance/SplitRuleContext.php
@@ -39,10 +39,10 @@ class SplitRuleContext extends BasicContext
         $this->splitRules = new SplitRuleCollection();
         $this->splitRules[]= self::getPagarMe()
             ->splitRule()
-            ->percentageRule(51, $this->createRecipient());
+            ->percentageRule(51, $this->createRecipient(), null, null, true);
         $this->splitRules[]=self::getPagarMe()
             ->splitRule()
-            ->percentageRule(49, $this->createRecipient());
+            ->percentageRule(49, $this->createRecipient(), null, null, false);
     }
 
     /**

--- a/tests/unit/SplitRule/SplitRuleHandlerTest.php
+++ b/tests/unit/SplitRule/SplitRuleHandlerTest.php
@@ -9,10 +9,10 @@ class SplitRuleHandlerTest extends \PHPUnit_Framework_TestCase
     public function splitData()
     {
         return [
-            [100, 123, true, false],
-            [666, 321, false, false],
-            [23, 233, null, false],
-            [42, 800, null, true],
+            [100, 123, true, false, true],
+            [666, 321, false, false, false],
+            [23, 233, null, false, true],
+            [42, 800, null, true, null],
         ];
     }
 
@@ -24,7 +24,8 @@ class SplitRuleHandlerTest extends \PHPUnit_Framework_TestCase
         $value,
         $recipientId,
         $liable,
-        $chargeProcessingFee
+        $chargeProcessingFee,
+        $chargeRemainder
     ) {
         $recipientMock = $this->getMockBuilder('PagarMe\Sdk\Recipient\Recipient')
             ->disableOriginalConstructor()
@@ -36,7 +37,8 @@ class SplitRuleHandlerTest extends \PHPUnit_Framework_TestCase
             $value,
             $recipientMock,
             $liable,
-            $chargeProcessingFee
+            $chargeProcessingFee,
+            $chargeRemainder
         );
 
         $this->assertEquals($value, $rule->getAmount());
@@ -44,6 +46,7 @@ class SplitRuleHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($liable, $rule->getLiable());
         $this->assertEquals($chargeProcessingFee, $rule->getChargeProcessingFee());
         $this->assertEquals($recipientId, $rule->getRecipient()->getId());
+        $this->assertEquals($chargeRemainder, $rule->getChargeRemainder());
     }
 
     /**
@@ -54,7 +57,8 @@ class SplitRuleHandlerTest extends \PHPUnit_Framework_TestCase
         $value,
         $recipientId,
         $liable,
-        $chargeProcessingFee
+        $chargeProcessingFee,
+        $chargeRemainder
     ) {
         $recipientMock = $this->getMockBuilder('PagarMe\Sdk\Recipient\Recipient')
             ->disableOriginalConstructor()
@@ -66,7 +70,8 @@ class SplitRuleHandlerTest extends \PHPUnit_Framework_TestCase
             $value,
             $recipientMock,
             $liable,
-            $chargeProcessingFee
+            $chargeProcessingFee,
+            $chargeRemainder
         );
 
         $this->assertEquals($value, $rule->getPercentage());
@@ -74,5 +79,6 @@ class SplitRuleHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($liable, $rule->getLiable());
         $this->assertEquals($chargeProcessingFee, $rule->getChargeProcessingFee());
         $this->assertEquals($recipientId, $rule->getRecipient()->getId());
+        $this->assertEquals($chargeRemainder, $rule->getChargeRemainder());
     }
 }


### PR DESCRIPTION
### Descrição

Adicionado possibilidade de enviar via SplitHandler a flag de `charge_remainder` para especificar de qual regra de split será cobrado os centavos a mais da transação ao invés de deixar sempre na primeira regra de split.

### Número da Issue

https://github.com/pagarme/pagarme-php/issues/190

### Testes Realizados
Atualizado o teste de aceitação para verificar que as transações continuam sendo criadas corretamente com o "novo parâmetro" e criado testes unitários para verificar que unidade e os métodos estão retornando os dados corretamente.

@devdrops @xduh @ricardotulio 
