### PR TITLE
Fix parameter name of the subscription update

### DIFF
--- a/lib/Subscription/SubscriptionBuilder.php
+++ b/lib/Subscription/SubscriptionBuilder.php
@@ -10,7 +10,12 @@ trait SubscriptionBuilder
 {
     use \PagarMe\Sdk\Transaction\TransactionBuilder;
 
-     /**
+    /**
+     * @var array $subscriptionData
+     */
+    public $subscriptionCookie;
+	
+    /**
      * @param array $subscriptionData
      * @return Subscription
      */
@@ -42,6 +47,14 @@ trait SubscriptionBuilder
             );
         }
 
-        return new Subscription(get_object_vars($subscriptionData));
+        $subscription = new Subscription(get_object_vars($subscriptionData));
+        $this->subscriptionCookie = new SubscriptionCookie($subscription);
+
+        return $subscription;
+    }
+   
+    public function getSubscriptionCookie()
+    {
+        return $this->subscriptionCookie;
     }
 }

--- a/lib/Subscription/SubscriptionCookie.php
+++ b/lib/Subscription/SubscriptionCookie.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace PagarMe\Sdk\Subscription;
+
+use PagarMe\Sdk\Card\Card;
+use PagarMe\Sdk\Plan\Plan;
+
+class SubscriptionCookie
+{
+    /**
+     * @var int $id
+     */
+    private $id;
+
+    /**
+     * @var Card $card
+     */
+    private $card;
+
+    /**
+     * @var Plan $plan
+     */
+    private $plan;
+
+    /**
+     * @var string $paymentMethod
+     */
+    private $paymentMethod;
+
+
+    /**
+     * @param Subscription $subscription
+     */
+    public function __construct(Subscription $subscription)
+    {
+        $this->setCard($subscription);
+        $this->setPlan($subscription);
+        $this->setPaymentMethod($subscription);
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function getId(Subscription $subscription)
+    {
+        $subscription->setId($this->id);
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function getCard(Subscription $subscription)
+    {
+        $subscription->setCard($this->card);
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function setCard(Subscription $subscription)
+    {
+        $this->card = $subscription->getCard();
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function getPlan(Subscription $subscription)
+    {
+        $subscription->setPlan($this->plan);
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function setPlan(Subscription $subscription)
+    {
+        $this->plan = $subscription->getPlan();
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function getPaymentMethod(Subscription $subscription)
+    {
+        $subscription->setPaymentMethod($this->paymentMethod);
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function setPaymentMethod(Subscription $subscription)
+    {
+        $this->paymentMethod = $subscription->getPaymentMethod();
+    }
+}

--- a/lib/Subscription/SubscriptionHandler.php
+++ b/lib/Subscription/SubscriptionHandler.php
@@ -103,7 +103,7 @@ class SubscriptionHandler extends AbstractHandler
         return $subscriptions;
     }
 
-    /**
+    /*
      * @param Subscription $subscription
      */
     public function cancel(Subscription $subscription)
@@ -120,7 +120,11 @@ class SubscriptionHandler extends AbstractHandler
      */
     public function update(Subscription $subscription)
     {
-        $request = new SubscriptionUpdate($subscription);
+	$subscriptionCookie = clone $subscription;
+	$this->getSubscriptionCookie()->getPlan($subscriptionCookie);
+	$this->getSubscriptionCookie()->getPaymentMethod($subscriptionCookie);	
+
+	$request = new SubscriptionUpdate($subscription, $subscriptionCookie);
 
         $response = $this->client->send($request);
 

--- a/tests/acceptance/SubscriptionContext.php
+++ b/tests/acceptance/SubscriptionContext.php
@@ -223,4 +223,17 @@ class SubscriptionContext extends BasicContext
             $this->transactions
         );
     }
+
+    /**
+     * @When I change the subscription plan
+     */
+    public function iChangeTheSubscriptionPlan()
+    {
+	$this->aValidPlan();
+	$this->subscription->setPlan($this->plan);
+        $this->subscription = self::getPagarMe()
+            ->subscription()
+            ->update($this->subscription);
+        $this->iQueryForTheSubscription();
+    }
 }

--- a/tests/acceptance/features/subscription.feature
+++ b/tests/acceptance/features/subscription.feature
@@ -37,3 +37,8 @@ Feature: Subscription
     Given a previous created subscription
     When I query the transactions of this subscription
     Then transactions must be returned
+
+ Scenario: Update the plan of the subscription
+    Given previous created subscriptions
+    When I change the subscription plan
+    Then the same subscription must be returned

--- a/tests/unit/Subscription/Request/SubscriptionUpdateTest.php
+++ b/tests/unit/Subscription/Request/SubscriptionUpdateTest.php
@@ -7,111 +7,127 @@ use PagarMe\Sdk\RequestInterface;
 
 class SubscriptionUpdateTest extends \PHPUnit_Framework_TestCase
 {
-    const PATH            = 'subscriptions/123';
     const SUBSCRIPTION_ID = 123;
-
     const CARD_ID     = 'card_123';
     const BOLETO      = 'boleto';
     const CREDIT_CARD = 'credit_card';
     const PLAN_ID     = 'plan_123';
 
-    /**
-     * @test
-     */
-    public function mustPayloadBeCorrectWhenNoCardSupplied()
+    private $subscriptionUpdateInstance = null;
+
+    public function setUp()
     {
-        $planMock = $this->getMockBuilder('PagarMe\Sdk\Plan\Plan')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $planMock->method('getId')->willReturn(self::PLAN_ID);
+        $subscriptionMock = $this->getMockSubscription();
+        $subscriptionCookieMock = $this->getMockSubscription();
+        $this->subscriptionUpdateInstance = new SubscriptionUpdate($subscriptionMock, $subscriptionCookieMock);
+    }
 
-        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
-        $subscriptionMock->method('getPlan')->willReturn($planMock);
-        $subscriptionMock->method('getPaymentMethod')->willReturn(self::BOLETO);
-        $subscriptionMock->method('getCard')->willReturn(null);
-
-        $subscriptionCancelRequest = new SubscriptionUpdate($subscriptionMock);
+    public function assertPreconditions()
+    {
+        $this->assertInstanceOf(
+            $name = 'PagarMe\Sdk\Subscription\Request\SubscriptionUpdate',
+            $this->subscriptionUpdateInstance,
+            "Expected instance of :{$name}");
 
         $this->assertEquals(
-            $subscriptionCancelRequest->getPayload(),
-            [
-                'plan'           => self::PLAN_ID,
-                'payment_method' => self::BOLETO
-            ]
+            RequestInterface::HTTP_PUT,
+            $this->subscriptionUpdateInstance->getMethod(),
+            "The HTTP verb must be :{RequestInterface::HTTP_PUT}"
+        );
+
+        $this->assertEquals(
+            $path = 'subscriptions/123',
+            $this->subscriptionUpdateInstance->getPath(),
+            "The URI must be : {$path}"
         );
     }
 
     /**
-     * @test
-     */
-    public function mustPayloadBeCorrectWhenCardSupplied()
+    * @dataProvider providerGetPayload
+    */
+    public function testPayDataIsLoadWithSuccess($subscription, $subscriptionCookie, $expected)
+    {
+        $this->subscriptionUpdateInstance = new SubscriptionUpdate($subscription, $subscriptionCookie);
+
+        $this->assertEquals($expected, $this->subscriptionUpdateInstance->getPayload());
+    }
+
+    public function providerGetPayload()
+    {
+        $cardNotSupplied = null;
+        $cardSupplied = $this->getMockCard(self::CARD_ID);
+        $planNotSupplied = $this->getMockPlan();
+        $planSupplied = $this->getMockPlan(self::PLAN_ID);
+
+        return [
+            'When we have NOTHING to load' => [
+                'subscription' => $this->getMockSubscription(),
+                'subscriptionCookie'=> $this->getMockSubscription(),
+                'expected' =>[]
+                ],
+            'When we have just one CARD supplied to load' => [
+                'subscription' => $this->getMockSubscription($cardSupplied),
+                'subscriptionCookie' => $this->getMockSubscription(),
+                'expected' =>['card_id' => self::CARD_ID]
+                ],
+            'When we have just one PLAN supplied to load' => [
+                'subscription' => $this->getMockSubscription($cardNotSupplied, $planSupplied),
+                'subscriptionCookie' => $this->getMockSubscription($cardNotSupplied, $this->getMockPlan()),
+                'expected' =>['plan_id' => self::PLAN_ID]
+                ],
+            'When we try load the same PLAN applied previously' => [
+                'subscription' => $this->getMockSubscription($cardNotSupplied, $planSupplied),
+                'subscriptionCookie' => $this->getMockSubscription($cardNotSupplied, $planSupplied),
+                'expected' =>[]
+                ],
+            'When we have just one PAYMENT METHOD supplied to load' => [
+                'subscription' => $this->getMockSubscription($cardNotSupplied, $planNotSupplied, self::BOLETO),
+                'subscriptionCookie' => $this->getMockSubscription($cardNotSupplied, $planNotSupplied),
+                'expected' =>['payment_method' => self::BOLETO]
+                ],
+            'When we try load the same PAYMENT METHOD applied previously' => [
+                'subscription' => $this->getMockSubscription($cardNotSupplied, $planNotSupplied, self::BOLETO),
+                'subscriptionCookie' => $this->getMockSubscription($cardNotSupplied, $planNotSupplied, self::BOLETO),
+                'expected' =>[]
+                ],
+            'When we have all parameters to load' => [
+                'subscription' => $this->getMockSubscription($cardSupplied, $planSupplied, self::BOLETO),
+                'subscriptionCookie' => $this->getMockSubscription($cardNotSupplied, $planNotSupplied, self::CREDIT_CARD),
+                'expected' =>['card_id' => self::CARD_ID, 'plan_id' => self::PLAN_ID, 'payment_method' => self::BOLETO]
+                ],  
+        ];
+    }
+
+    public function getMockSubscription($card = null, $plan = null, $paymentMethod = null)
+    {
+        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
+        $subscriptionMock->method('getCard')->willReturn($card);
+        $subscriptionMock->method('getPlan')->willReturn($plan);
+        $subscriptionMock->method('getPaymentMethod')->willReturn($paymentMethod);
+
+        return $subscriptionMock;
+    }
+
+    public function getMockPlan($planId = null)
+    {
+        $planMock = $this->getMockBuilder('PagarMe\Sdk\Plan\Plan')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $planMock->method('getId')->willReturn($planId);
+
+        return $planMock;
+    }
+
+    public function getMockCard($cardId = null)
     {
         $cardMock = $this->getMockBuilder('PagarMe\Sdk\Card\Card')
             ->disableOriginalConstructor()
             ->getMock();
-        $cardMock->method('getId')->willReturn(self::CARD_ID);
+        $cardMock->method('getId')->willReturn($cardId);
 
-
-        $planMock = $this->getMockBuilder('PagarMe\Sdk\Plan\Plan')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $planMock->method('getId')->willReturn(self::PLAN_ID);
-
-        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
-        $subscriptionMock->method('getPlan')->willReturn($planMock);
-        $subscriptionMock->method('getPaymentMethod')->willReturn(self::BOLETO);
-        $subscriptionMock->method('getCard')->willReturn($cardMock);
-
-        $subscriptionCancelRequest = new SubscriptionUpdate($subscriptionMock);
-
-        $this->assertEquals(
-            $subscriptionCancelRequest->getPayload(),
-            [
-                'plan'           => self::PLAN_ID,
-                'payment_method' => self::BOLETO,
-                'card_id'        => self::CARD_ID
-            ]
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function mustMethodBeCorrect()
-    {
-        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $subscriptionCancelRequest = new SubscriptionUpdate($subscriptionMock);
-
-        $this->assertEquals(
-            $subscriptionCancelRequest->getMethod(),
-            RequestInterface::HTTP_PUT
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function mustPathBeCorrect()
-    {
-        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
-
-        $subscriptionCancelRequest = new SubscriptionUpdate($subscriptionMock);
-
-        $this->assertEquals(
-            $subscriptionCancelRequest->getPath(),
-            self::PATH
-        );
+        return $cardMock;
     }
 }

--- a/tests/unit/Subscription/SubscriptionBuilderTest.php
+++ b/tests/unit/Subscription/SubscriptionBuilderTest.php
@@ -2,9 +2,10 @@
 
 namespace PagarMe\SdkTest\Subscription;
 
-class SubscriptionGetTest extends \PHPUnit_Framework_TestCase
+class SubscriptionBuilderTest extends \PHPUnit_Framework_TestCase
 {
     use \PagarMe\Sdk\Subscription\SubscriptionBuilder;
+    const PLAN_ID = 'plan_123';
 
     /**
      * @test


### PR DESCRIPTION
Changes the parameter name plan id, use 'plan_id' instead of 'plan'
in method 'getPayload' because the body with 'plan' is doesn't accepted
by API in route PUT /subscriptions/:id

Example:
from
 {"plan":"999",...}
to
 {"plan_id":"999",...}

Unit tests updated.