### PR TITLE
Changes the mandatory parameters to update subscription route

### DIFF
--- a/lib/Subscription/Request/SubscriptionUpdate.php
+++ b/lib/Subscription/Request/SubscriptionUpdate.php
@@ -7,17 +7,27 @@ use PagarMe\Sdk\Subscription\Subscription;
 
 class SubscriptionUpdate implements RequestInterface
 {
+    const CREDIT_CARD = 'credit_card';
+    const BOLETO = 'boleto';
+
     /**
      * @var Subscription $subscription
      */
     protected $subscription;
 
     /**
-     * @var Subscription $subscription
+     * @var Subscription $subscriptionMemento
      */
-    public function __construct(Subscription $subscription)
+    protected $subscriptionMemento;
+
+    /**
+     * @param Subscription $subscription
+     * @param Subscription $subscriptionMemento
+     */
+    public function __construct(Subscription $subscription, Subscription $subscriptionMemento)
     {
         $this->subscription = $subscription;
+        $this->subscriptionMemento = $subscriptionMemento;
     }
 
     /**
@@ -25,17 +35,79 @@ class SubscriptionUpdate implements RequestInterface
      */
     public function getPayload()
     {
-        $payload = [
-            'plan'           => $this->subscription->getPlan()->getId(),
-            'payment_method' => $this->subscription->getPaymentMethod()
-        ];
+        $payload = new \ArrayObject();
+        $this->loadCard($payload);
+        $this->loadPlanId($payload);
+        $this->loadPaymentMethod($payload);
+        
+        return $payload->getArrayCopy();
+    }
 
-        $card = $this->subscription->getCard();
-        if ($card instanceof \PagarMe\Sdk\Card\Card) {
-            $payload['card_id'] = $this->subscription->getCard()->getId();
+    /**
+     * @param ArrayObject $payload
+     * @return ArrayObject $payload
+     */
+    protected function loadCard(\ArrayObject $payload)
+    {
+        $newCard = $this->subscription->getCard();
+        $mementoCard = $this->subscriptionMemento->getCard();
+        
+        if (!$newCard instanceof \PagarMe\Sdk\Card\Card || !$mementoCard instanceof \PagarMe\Sdk\Card\Card) {
+            return $payload;
         }
 
-        return $payload;
+        if ($this->isCardIdChanged() || $this->isPreviousPaymentMethodBoleto()) {
+            $payload->offsetSet('card_id', $newCard->getId());
+            $payload->offsetSet('payment_method', self::CREDIT_CARD);
+        }
+    }
+
+    /**
+     * @return bool 
+     */
+    protected function isCardIdChanged()
+    {
+        return $this->subscription->getCard()->getId() != $this->subscriptionMemento->getCard()->getId();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isPreviousPaymentMethodBoleto()
+    {
+       return $this->subscriptionMemento->getPaymentMethod() == self::BOLETO;
+    }
+
+    /**
+     * @param ArrayObject $payload
+     * @return ArrayObject $payload
+     */
+    protected function loadPlanId(\ArrayObject $payload)
+    {
+        $newPlan = $this->subscription->getPlan();
+        $mementoPlan = $this->subscriptionMemento->getPlan();
+
+        if (!$newPlan instanceof \PagarMe\Sdk\Plan\Plan || !$mementoPlan instanceof \PagarMe\Sdk\Plan\Plan) {
+            return $payload;
+        }
+
+        if ($newPlan->getId() != $mementoPlan->getId()) {
+           $payload->offsetSet('plan_id', $newPlan->getId());
+        }
+    }
+
+    /**
+     * @param ArrayObject $payload
+     * @return ArrayObject $payload
+     */
+    protected function loadPaymentMethod(\ArrayObject $payload)
+    { 
+        $newPaymentMethod = $this->subscription->getPaymentMethod();
+        $mementoPaymentMethod = $this->subscriptionMemento->getPaymentMethod();
+
+        if ($newPaymentMethod != $mementoPaymentMethod) {
+            $payload->offsetSet('payment_method', $newPaymentMethod);
+        }
     }
 
     /**

--- a/lib/Subscription/SubscriptionBuilder.php
+++ b/lib/Subscription/SubscriptionBuilder.php
@@ -10,7 +10,12 @@ trait SubscriptionBuilder
 {
     use \PagarMe\Sdk\Transaction\TransactionBuilder;
 
-     /**
+    /**
+     * @var SubscriptonMemento $subscriptionMemento
+     */
+    public $subscriptionMemento;
+	
+    /**
      * @param array $subscriptionData
      * @return Subscription
      */
@@ -42,6 +47,14 @@ trait SubscriptionBuilder
             );
         }
 
-        return new Subscription(get_object_vars($subscriptionData));
+        $subscription = new Subscription(get_object_vars($subscriptionData));
+        $this->subscriptionMemento = new SubscriptionMemento($subscription);
+
+        return $subscription;
+    }
+   
+    public function getSubscriptionMemento()
+    {
+        return $this->subscriptionMemento;
     }
 }

--- a/lib/Subscription/SubscriptionHandler.php
+++ b/lib/Subscription/SubscriptionHandler.php
@@ -120,11 +120,16 @@ class SubscriptionHandler extends AbstractHandler
      */
     public function update(Subscription $subscription)
     {
-        $request = new SubscriptionUpdate($subscription);
+	$subscriptionMemento = clone $subscription;
+	$this->getSubscriptionMemento()->getPlan($subscriptionMemento);
+	$this->getSubscriptionMemento()->getPaymentMethod($subscriptionMemento);
+       $this->getSubscriptionMemento()->getCard($subscriptionMemento);
 
-        $response = $this->client->send($request);
+       $request = new SubscriptionUpdate($subscription, $subscriptionMemento);
 
-        return $this->buildSubscription($response);
+       $response = $this->client->send($request);
+        
+       return $this->buildSubscription($response);
     }
 
     /**

--- a/lib/Subscription/SubscriptionMemento.php
+++ b/lib/Subscription/SubscriptionMemento.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace PagarMe\Sdk\Subscription;
+
+use PagarMe\Sdk\Card\Card;
+use PagarMe\Sdk\Plan\Plan;
+
+class SubscriptionMemento
+{
+    /**
+     * @var int $id
+     */
+    private $id;
+
+    /**
+     * @var Card $card
+     */
+    private $card;
+
+    /**
+     * @var Plan $plan
+     */
+    private $plan;
+
+    /**
+     * @var string $paymentMethod
+     */
+    private $paymentMethod;
+
+    /**
+     * @param Subscription $subscription
+     */
+    public function __construct(Subscription $subscription)
+    {
+        $this->setCard($subscription);
+        $this->setPlan($subscription);
+        $this->setPaymentMethod($subscription);
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function getId(Subscription $subscription)
+    {
+        $subscription->setId($this->id);
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function getCard(Subscription $subscription)
+    { 
+       if ($this->card instanceof \PagarMe\Sdk\Card\Card) {
+           $subscription->setCard($this->card);
+       }
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function setCard(Subscription $subscription)
+    {
+        $this->card = $subscription->getCard();
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function getPlan(Subscription $subscription)
+    {
+        $subscription->setPlan($this->plan);
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function setPlan(Subscription $subscription)
+    {
+        $this->plan = $subscription->getPlan();
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function getPaymentMethod(Subscription $subscription)
+    {
+        $subscription->setPaymentMethod($this->paymentMethod);
+    }
+
+    /**
+     * @param Subscription $subscription
+     * @codeCoverageIgnore
+     */
+    public function setPaymentMethod(Subscription $subscription)
+    {
+        $this->paymentMethod = $subscription->getPaymentMethod();
+    }
+}

--- a/tests/acceptance/SubscriptionContext.php
+++ b/tests/acceptance/SubscriptionContext.php
@@ -55,21 +55,21 @@ class SubscriptionContext extends BasicContext
     /**
      * @Given a valid plan
      */
-    public function aValidPlan()
+    public function aValidPlan($planName = 'Test Plan')
     {
         $this->plan = self::getPagarMe()
             ->plan()
-            ->create(555, 30, 'Test Plan');
+            ->create(555, 30, $planName);
     }
 
     /**
      * @Given a valid card
      */
-    public function aValidCard()
+    public function aValidCard($cardNumber = '4539706041746367')
     {
         $this->creditCard = self::getPagarMe()
             ->card()
-            ->create('4539706041746367', "John Doe", '0725');
+            ->create($cardNumber, "John Doe", '0725');
     }
 
     /**
@@ -127,6 +127,17 @@ class SubscriptionContext extends BasicContext
         $this->aValidCustomer();
         $this->aValidPlan();
         $this->makeABoletoSubscription();
+    }
+
+    /**
+     * @Given a previous created credit card subscription
+     */
+    public function aPreviousCreatedCreditCardSubscription()
+    {
+        $this->aValidCustomer();
+        $this->aValidPlan();
+	$this->aValidCard();
+        $this->makeACreditCardSubscription();
     }
 
     /**
@@ -223,4 +234,68 @@ class SubscriptionContext extends BasicContext
             $this->transactions
         );
     }
+
+    /**
+     * @When I update the subscription to use plan name :planName
+     */
+    public function iUpdateTheSubscriptionToUsePlan($planName)
+    {
+	$this->aValidPlan($planName);
+	$this->subscription->setPlan($this->plan);
+        $this->subscription = self::getPagarMe()
+            ->subscription()
+            ->update($this->subscription);
+        $this->iQueryForTheSubscription();
+    }
+
+    /**
+     * @When I update the subscription to use card number :cardNumber
+     */
+    public function iUpdateTheSubscriptionToUseCardNumber($cardNumber)
+    {
+        $this->aValidCard($cardNumber);
+        $this->subscription->setCard($this->creditCard);
+        $this->subscription = self::getPagarMe()
+            ->subscription()
+            ->update($this->subscription);
+        $this->iQueryForTheSubscription();
+    }
+
+    /**
+     * @Then must contain :needle in :key
+     */
+    public function mustContain($needle, $key)
+    {
+        $variableMethod = "get{$key}";
+        $objectAttribute = call_user_func([$this->querySubscription, $variableMethod]);
+        $serializeAttribute = json_encode((array) $objectAttribute);
+        assertContains($needle, $serializeAttribute);
+    }
+
+
+    /**
+     * @When I update the subscription to use payment method :paymentMethod
+     */
+    public function iUpdateTheSubscriptionPaymentMethod($paymentMethod)
+    {
+        $this->subscription->setPaymentMethod($paymentMethod);
+        $this->subscription = self::getPagarMe()
+            ->subscription()
+            ->update($this->subscription);
+        $this->iQueryForTheSubscription();
+    }
+
+    /**
+     * @When I change the subscription all
+     */
+    public function iChangeTheSubscriptionAll()
+    {
+        $this->aValidPlan();
+        $this->subscription->setPlan($this->plan);
+        $this->subscription = self::getPagarMe()
+            ->subscription()
+            ->update($this->subscription);
+        $this->iQueryForTheSubscription();
+    }
+
 }

--- a/tests/acceptance/features/subscription.feature
+++ b/tests/acceptance/features/subscription.feature
@@ -37,3 +37,36 @@ Feature: Subscription
     Given a previous created subscription
     When I query the transactions of this subscription
     Then transactions must be returned
+
+ Scenario: Update the plan of the subscription
+    Given previous created subscriptions
+    When I update the subscription to use plan name 'Gold Plan'
+    Then the same subscription must be returned
+    And must contain 'Gold Plan' in 'Plan'
+
+ Scenario: Update the card of the subscription
+    Given a previous created credit card subscription
+    When I update the subscription to use card number '5433553684826195'
+    Then the same subscription must be returned 
+    And must contain '543355' in 'Card'
+
+ Scenario: Update the payment method of the subscription
+    Given previous created subscriptions
+    When I update the subscription to use payment method 'boleto'
+    Then the same subscription must be returned
+    And must contain 'boleto' in 'PaymentMethod'
+
+ Scenario: Update the subscription to card instead of boleto
+    Given previous created subscriptions
+    When I update the subscription to use card number '5433553684826195'
+    Then the same subscription must be returned
+    And must contain '543355' in 'Card'
+
+ Scenario: Update the subscription payment method, card and plan together
+    Given previous created subscriptions
+    When I update the subscription to use card number '5433553684826195'
+    And I update the subscription to use plan name 'Gold Plan'
+    Then the same subscription must be returned
+    And must contain '543355' in 'Card'
+    And must contain 'Gold Plan' in 'Plan'
+    And must contain 'credit_card' in 'PaymentMethod'

--- a/tests/unit/Subscription/Request/SubscriptionUpdateTest.php
+++ b/tests/unit/Subscription/Request/SubscriptionUpdateTest.php
@@ -7,111 +7,127 @@ use PagarMe\Sdk\RequestInterface;
 
 class SubscriptionUpdateTest extends \PHPUnit_Framework_TestCase
 {
-    const PATH            = 'subscriptions/123';
     const SUBSCRIPTION_ID = 123;
-
     const CARD_ID     = 'card_123';
     const BOLETO      = 'boleto';
     const CREDIT_CARD = 'credit_card';
     const PLAN_ID     = 'plan_123';
 
-    /**
-     * @test
-     */
-    public function mustPayloadBeCorrectWhenNoCardSupplied()
+    private $subscriptionUpdateInstance = null;
+
+    public function setUp()
     {
-        $planMock = $this->getMockBuilder('PagarMe\Sdk\Plan\Plan')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $planMock->method('getId')->willReturn(self::PLAN_ID);
+        $subscriptionMock = $this->getMockSubscription();
+        $subscriptionMementoMock = $this->getMockSubscription();
+        $this->subscriptionUpdateInstance = new SubscriptionUpdate($subscriptionMock, $subscriptionMementoMock);
+    }
 
-        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
-        $subscriptionMock->method('getPlan')->willReturn($planMock);
-        $subscriptionMock->method('getPaymentMethod')->willReturn(self::BOLETO);
-        $subscriptionMock->method('getCard')->willReturn(null);
-
-        $subscriptionCancelRequest = new SubscriptionUpdate($subscriptionMock);
+    public function assertPreconditions()
+    {
+        $this->assertInstanceOf(
+            $name = 'PagarMe\Sdk\Subscription\Request\SubscriptionUpdate',
+            $this->subscriptionUpdateInstance,
+            "Expected instance of :{$name}");
 
         $this->assertEquals(
-            $subscriptionCancelRequest->getPayload(),
-            [
-                'plan'           => self::PLAN_ID,
-                'payment_method' => self::BOLETO
-            ]
+            RequestInterface::HTTP_PUT,
+            $this->subscriptionUpdateInstance->getMethod(),
+            "The HTTP verb must be :{RequestInterface::HTTP_PUT}"
+        );
+
+        $this->assertEquals(
+            $path = 'subscriptions/123',
+            $this->subscriptionUpdateInstance->getPath(),
+            "The URI must be : {$path}"
         );
     }
 
     /**
-     * @test
-     */
-    public function mustPayloadBeCorrectWhenCardSupplied()
+    * @dataProvider providerGetPayload
+    */
+    public function testPayDataIsLoadWithSuccess($subscription, $subscriptionMemento, $expected)
+    {
+        $this->subscriptionUpdateInstance = new SubscriptionUpdate($subscription, $subscriptionMemento);
+
+        $this->assertEquals($expected, $this->subscriptionUpdateInstance->getPayload());
+    }
+
+    public function providerGetPayload()
+    {
+        $cardNotSupplied = null;
+        $cardSupplied = $this->getMockCard(self::CARD_ID);
+        $planNotSupplied = $this->getMockPlan();
+        $planSupplied = $this->getMockPlan(self::PLAN_ID);
+
+        return [
+            'When we have NOTHING to load' => [
+                'subscription' => $this->getMockSubscription(),
+                'subscriptionMemento'=> $this->getMockSubscription(),
+                'expected' =>[]
+                ],
+            'When we have just one CARD supplied to load' => [
+                'subscription' => $this->getMockSubscription($cardSupplied),
+                'subscriptionMemento' => $this->getMockSubscription($this->getMockCard(rand())),
+                'expected' =>['payment_method' => self::CREDIT_CARD, 'card_id' => self::CARD_ID]
+                ],
+            'When we have just one PLAN supplied to load' => [
+                'subscription' => $this->getMockSubscription($cardNotSupplied, $planSupplied),
+                'subscriptionMemento' => $this->getMockSubscription($cardNotSupplied, $this->getMockPlan()),
+                'expected' =>['plan_id' => self::PLAN_ID]
+                ],
+            'When we try load the same PLAN applied previously' => [
+                'subscription' => $this->getMockSubscription($cardNotSupplied, $planSupplied),
+                'subscriptionMemento' => $this->getMockSubscription($cardNotSupplied, $planSupplied),
+                'expected' =>[]
+                ],
+            'When we have just one PAYMENT METHOD supplied to load' => [
+                'subscription' => $this->getMockSubscription($cardNotSupplied, $planNotSupplied, self::BOLETO),
+                'subscriptionMemento' => $this->getMockSubscription($cardNotSupplied, $planNotSupplied),
+                'expected' =>['payment_method' => self::BOLETO]
+                ],
+            'When we try load the same PAYMENT METHOD applied previously' => [
+                'subscription' => $this->getMockSubscription($cardNotSupplied, $planNotSupplied, self::BOLETO),
+                'subscriptionMemento' => $this->getMockSubscription($cardNotSupplied, $planNotSupplied, self::BOLETO),
+                'expected' =>[]
+                ],
+            'When we have all parameters to load' => [
+                'subscription' => $this->getMockSubscription($cardSupplied, $planSupplied, self::CREDIT_CARD),
+                'subscriptionMemento' => $this->getMockSubscription($cardSupplied, $planNotSupplied, self::BOLETO),
+                'expected' =>['card_id' => self::CARD_ID, 'plan_id' => self::PLAN_ID, 'payment_method' => self::CREDIT_CARD]
+                ],  
+        ];
+    }
+
+    public function getMockSubscription($card = null, $plan = null, $paymentMethod = null)
+    {
+        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
+        $subscriptionMock->method('getCard')->willReturn($card);
+        $subscriptionMock->method('getPlan')->willReturn($plan);
+        $subscriptionMock->method('getPaymentMethod')->willReturn($paymentMethod);
+
+        return $subscriptionMock;
+    }
+
+    public function getMockPlan($planId = null)
+    {
+        $planMock = $this->getMockBuilder('PagarMe\Sdk\Plan\Plan')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $planMock->method('getId')->willReturn($planId);
+
+        return $planMock;
+    }
+
+    public function getMockCard($cardId = null)
     {
         $cardMock = $this->getMockBuilder('PagarMe\Sdk\Card\Card')
             ->disableOriginalConstructor()
             ->getMock();
-        $cardMock->method('getId')->willReturn(self::CARD_ID);
+        $cardMock->method('getId')->willReturn($cardId);
 
-
-        $planMock = $this->getMockBuilder('PagarMe\Sdk\Plan\Plan')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $planMock->method('getId')->willReturn(self::PLAN_ID);
-
-        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
-        $subscriptionMock->method('getPlan')->willReturn($planMock);
-        $subscriptionMock->method('getPaymentMethod')->willReturn(self::BOLETO);
-        $subscriptionMock->method('getCard')->willReturn($cardMock);
-
-        $subscriptionCancelRequest = new SubscriptionUpdate($subscriptionMock);
-
-        $this->assertEquals(
-            $subscriptionCancelRequest->getPayload(),
-            [
-                'plan'           => self::PLAN_ID,
-                'payment_method' => self::BOLETO,
-                'card_id'        => self::CARD_ID
-            ]
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function mustMethodBeCorrect()
-    {
-        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $subscriptionCancelRequest = new SubscriptionUpdate($subscriptionMock);
-
-        $this->assertEquals(
-            $subscriptionCancelRequest->getMethod(),
-            RequestInterface::HTTP_PUT
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function mustPathBeCorrect()
-    {
-        $subscriptionMock = $this->getMockBuilder('PagarMe\Sdk\Subscription\Subscription')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $subscriptionMock->method('getId')->willReturn(self::SUBSCRIPTION_ID);
-
-        $subscriptionCancelRequest = new SubscriptionUpdate($subscriptionMock);
-
-        $this->assertEquals(
-            $subscriptionCancelRequest->getPath(),
-            self::PATH
-        );
+        return $cardMock;
     }
 }

--- a/tests/unit/Subscription/SubscriptionBuilderTest.php
+++ b/tests/unit/Subscription/SubscriptionBuilderTest.php
@@ -2,9 +2,10 @@
 
 namespace PagarMe\SdkTest\Subscription;
 
-class SubscriptionGetTest extends \PHPUnit_Framework_TestCase
+class SubscriptionBuilderTest extends \PHPUnit_Framework_TestCase
 {
     use \PagarMe\Sdk\Subscription\SubscriptionBuilder;
+    const PLAN_ID = 'plan_123';
 
     /**
      * @test


### PR DESCRIPTION
It's not mandatory to send all parameters to the update. It's possible to change,
for instance, only the plan_id without to alter the card or the payment method.
To implement it, we use the "memento pattern" instead to make a new request of
the early data subscription.

Changes the "plan_id" parameter name. Use "plan_id" instead of "plan" because the body
of request with "plan" is not accepted by API in the route PUT /subscriptions/:id.

Sends the payment method "credit_card" when "card_id" is inform, because the API
require the payment method together to this update.

Create methods to load the card, plan and payment method with specific validations
to be attached in the body of the request.

Changes unit tests and creates behaviour tests.