### PR TITLE
Filter transactions

### DIFF
--- a/lib/Transaction/Request/TransactionFind.php
+++ b/lib/Transaction/Request/TransactionFind.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace PagarMe\Sdk\Transaction\Request;
+
+use PagarMe\Sdk\RequestInterface;
+
+class TransactionFind implements RequestInterface
+{
+    /**
+     * @var int
+     */
+    private $page;
+
+    /**
+     * @var int
+     */
+    private $limit;
+
+    /**
+     * @var array
+     */
+    private $filters;
+
+    /**
+     * @param array $filters
+     * @param int   $page
+     * @param int   $limit
+     */
+    public function __construct(array $filters, $page, $limit)
+    {
+        $this->page = $page;
+        $this->limit = $limit;
+        $this->filters = $filters;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPayload()
+    {
+        return array_merge($this->filters, [
+            'page' => $this->page,
+            'count' => $this->limit,
+        ]);
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return 'transactions';
+    }
+
+    public function getMethod()
+    {
+        return self::HTTP_GET;
+    }
+}

--- a/lib/Transaction/TransactionHandler.php
+++ b/lib/Transaction/TransactionHandler.php
@@ -3,20 +3,21 @@
 namespace PagarMe\Sdk\Transaction;
 
 use PagarMe\Sdk\AbstractHandler;
-use PagarMe\Sdk\Client;
-use PagarMe\Sdk\Transaction\Request\CreditCardTransactionCreate;
-use PagarMe\Sdk\Transaction\Request\BoletoTransactionCreate;
-use PagarMe\Sdk\Transaction\Request\TransactionGet;
-use PagarMe\Sdk\Transaction\Request\TransactionList;
-use PagarMe\Sdk\Transaction\Request\TransactionCapture;
-use PagarMe\Sdk\Transaction\Request\TransactionEvents;
-use PagarMe\Sdk\Transaction\Request\CreditCardTransactionRefund;
-use PagarMe\Sdk\Transaction\Request\BoletoTransactionRefund;
-use PagarMe\Sdk\Transaction\Request\TransactionPay;
 use PagarMe\Sdk\BankAccount\BankAccount;
 use PagarMe\Sdk\Card\Card;
+use PagarMe\Sdk\Client;
 use PagarMe\Sdk\Customer\Customer;
 use PagarMe\Sdk\Recipient\Recipient;
+use PagarMe\Sdk\Transaction\Request\BoletoTransactionCreate;
+use PagarMe\Sdk\Transaction\Request\BoletoTransactionRefund;
+use PagarMe\Sdk\Transaction\Request\CreditCardTransactionCreate;
+use PagarMe\Sdk\Transaction\Request\CreditCardTransactionRefund;
+use PagarMe\Sdk\Transaction\Request\TransactionCapture;
+use PagarMe\Sdk\Transaction\Request\TransactionEvents;
+use PagarMe\Sdk\Transaction\Request\TransactionFind;
+use PagarMe\Sdk\Transaction\Request\TransactionGet;
+use PagarMe\Sdk\Transaction\Request\TransactionList;
+use PagarMe\Sdk\Transaction\Request\TransactionPay;
 
 class TransactionHandler extends AbstractHandler
 {
@@ -127,6 +128,22 @@ class TransactionHandler extends AbstractHandler
         }
 
         return $transactions;
+    }
+
+    /**
+     * @param  array $filters
+     * @param  int   $page
+     * @param  int   $limit
+     * @return array
+     */
+    public function find(array $filters, $page = null, $limit = null)
+    {
+        $request = new TransactionFind($filters, $page, $limit);
+        $response = $this->client->send($request);
+
+        return array_map(function ($transaction) {
+            return $this->buildTransaction($transaction);
+        }, $response);
     }
 
     /**

--- a/tests/acceptance/TransactionContext.php
+++ b/tests/acceptance/TransactionContext.php
@@ -4,9 +4,9 @@ namespace PagarMe\Acceptance;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use PagarMe\Sdk\Customer\Customer;
 
@@ -450,6 +450,39 @@ class TransactionContext extends BasicContext
     public function refundedTransactionMustBeReturned()
     {
         assertTrue($this->transaction->isPendingRefund());
+    }
+
+    /**
+     * @Given I have multiple transactions registered
+     */
+    public function iHaveMultipleTransactionsRegistered()
+    {
+        $this->aValidCard();
+        $this->aValidCustomer();
+        $this->makeABoletoTransactionWithRandomAmountAndMetadata();
+        $this->makeACreditCardTransactionWithRandomAmountAndMetadata();
+    }
+
+    /**
+     * @When I use the filter :filter equals to :value
+     */
+    public function iUseTheFilterEqualsTo($filter, $value)
+    {
+        $this->transactionList = self::getPagarMe()
+            ->transaction()
+            ->find([$filter => $value]);
+    }
+
+    /**
+     * @Then an array with just transactions with :property equals to :value should be returned
+     */
+    public function anArrayWithJustTransactionsWithEqualsToShouldBeReturned($property, $value)
+    {
+        assertContainsOnly('PagarMe\Sdk\Transaction\AbstractTransaction', $this->transactionList);
+
+        foreach ($this->transactionList as $transaction) {
+            assertEquals($value, $transaction->{$property}());
+        }
     }
 
     private function getRandomMetadata()

--- a/tests/acceptance/features/transaction.feature
+++ b/tests/acceptance/features/transaction.feature
@@ -135,6 +135,15 @@ Feature: Transaction
     When a valid boleto transaction
     Then then transaction must be retriavable
 
+  Scenario Outline: Filtering transactions
+    Given I have multiple transactions registered
+    When I use the filter "<filter>" equals to "<value>"
+    Then an array with just transactions with "<property>" equals to "<value>" should be returned
+    Examples:
+      | property         | filter         | value       |
+      | getPaymentMethod | payment_method | boleto      |
+      | getPaymentMethod | payment_method | credit_card |
+
   Scenario: Getting transaction events
     Given I had a transactions registered
     When query transactions events

--- a/tests/unit/Transaction/Request/TransactionFindTest.php
+++ b/tests/unit/Transaction/Request/TransactionFindTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PagarMe\SdkTest\Transaction\Request;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use PagarMe\Sdk\Transaction\Request\TransactionFind;
+
+class TransactionFindTest extends TestCase
+{
+    const PATH = 'transactions';
+
+    public function filtersProvider()
+    {
+        return [
+            [[], null, null],
+            [[], 2, null],
+            [[], 1, 5],
+            [['id' => 123456], 4, 10],
+            [['reference_key' => 'abcd123456'], 7, 20],
+            [['amount' => 100, 'page' => 2, 'count' => 3], 7, 20],
+        ];
+    }
+
+    /**
+     * @dataProvider filtersProvider
+     */
+    public function testIfThePayloadIsCorrect($filters, $page, $limit)
+    {
+        $transactionFind = new TransactionFind($filters, $page, $limit);
+        $expectedPayload = array_merge($filters, [
+            'page' => $page,
+            'count' => $limit,
+        ]);
+
+        $this->assertEquals($expectedPayload, $transactionFind->getPayload());
+    }
+
+    /**
+     * @dataProvider filtersProvider
+     */
+    public function testIfThePathIsCorrect($filters, $page, $limit)
+    {
+        $transactionFind = new TransactionFind($filters, $page, $limit);
+        $this->assertEquals(self::PATH, $transactionFind->getPath());
+    }
+
+    /**
+     * @dataProvider filtersProvider
+     */
+    public function testIfTheMethodIsCorrect($filters, $page, $limit)
+    {
+        $transactionFind = new TransactionFind($filters, $page, $limit);
+        $this->assertEquals('GET', $transactionFind->getMethod());
+    }
+}


### PR DESCRIPTION
### Description

Today we can't filter transactions to get a more precise list of them, we can only list all transactions but without any kind of filters.

To solve that we create a method called "find" that accepts a list of parameters exactly as the [API describes](https://docs.pagar.me/reference#retornando-transações) to filter the transactions with more flexibility.

Just a quick example of how to use the `find` method:

``` php
$apiKey = 'MYAPIKEYFORTESTSONLY';
$pagarme = new \PagarMe\Sdk\PagarMe($apiKey);

$pagarme->transaction()->find([
    'payment_method' => 'boleto',
    'reference_key' => 'SVQQ04PE8PFIECEIZLRINSJIZ136XLKW',
]);
```

> The [wiki](https://github.com/pagarme/pagarme-php/wiki) will probably need to be updated to document this new feature :)

### Tests
Unit and acceptance tests were applied.
