### PR TITLE
Usar versão instalada do PHPUnit, não a global

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 script:
   - vendor/bin/phpunit
   - vendor/bin/behat
-  - phpunit --coverage-clover build/logs/clover.xml
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_success:
   - sh -c 'php vendor/bin/coveralls -v'


### PR DESCRIPTION
### Descrição

Usar a versão instalada do `PHPUnit`, não a global, pois pode causar incompatibilidade.

### Número da Issue

Descoberto em #228 nos [testes de `PHP 7`](https://travis-ci.org/pagarme/pagarme-php/jobs/306394373).

### Testes Realizados

Todos [os testes](https://travis-ci.org/pagarme/pagarme-php/builds/306394369) do PR #228 passaram, exceto o de `PHP 7`.

@devdrops 
