### PR TITLE
Remove installments from AbstractTransaction

### DIFF
--- a/lib/Transaction/AbstractTransaction.php
+++ b/lib/Transaction/AbstractTransaction.php
@@ -286,15 +286,6 @@ abstract class AbstractTransaction
      * @return int
      * @codeCoverageIgnore
      */
-    public function getInstallments()
-    {
-        return $this->installments;
-    }
-
-    /**
-     * @return int
-     * @codeCoverageIgnore
-     */
     public function getCost()
     {
         return $this->cost;


### PR DESCRIPTION
### Description

Since `BoletoTransactions` can not be paid on installments and shouldn't
have `getInstallments` method this creates moves `$installments` field
ant its getter method to `CreditCardTransaction`.

### Issue

There's no issue

### Tests

No tests added