### PR TITLE
feature: add cvv to card payload

### DIFF
--- a/lib/Card/CardHandler.php
+++ b/lib/Card/CardHandler.php
@@ -17,14 +17,16 @@ class CardHandler extends AbstractHandler
      * @param int $cardNumber
      * @param string $holderName
      * @param string $cardExpirationDate
+     * @param int $cardCvv
      * @return Card
      */
-    public function create($cardNumber, $holderName, $cardExpirationDate)
+    public function create($cardNumber, $holderName, $cardExpirationDate, $cardCvv = null)
     {
         $request = new CardCreate(
             $cardNumber,
             $holderName,
-            $cardExpirationDate
+            $cardExpirationDate,
+            $cardCvv
         );
 
         $response = $this->client->send($request);

--- a/lib/Card/Request/CardCreate.php
+++ b/lib/Card/Request/CardCreate.php
@@ -22,15 +22,22 @@ class CardCreate implements RequestInterface
     private $cardExpirationDate;
 
     /**
+     * @var int
+     */
+    private $cardCvv;
+
+    /**
      * @param int $cardNumber
      * @param string $holderName
      * @param int $cardExpirationDate
+     * @param int $cardCvv
      */
-    public function __construct($cardNumber, $holderName, $cardExpirationDate)
+    public function __construct($cardNumber, $holderName, $cardExpirationDate, $cardCvv = null)
     {
         $this->cardNumber         = $cardNumber;
         $this->holderName         = $holderName;
         $this->cardExpirationDate = $cardExpirationDate;
+        $this->cardCvv            = $cardCvv;
     }
 
     /**
@@ -38,11 +45,17 @@ class CardCreate implements RequestInterface
      */
     public function getPayload()
     {
-        return [
+        $cardData = [
             'card_number'          => $this->cardNumber,
             'holder_name'          => $this->holderName,
             'card_expiration_date' => $this->cardExpirationDate
         ];
+
+        if (!is_null($this->cardCvv)) {
+            $cardData['card_cvv'] = $this->cardCvv;
+        }
+
+        return $cardData;
     }
 
     /**

--- a/tests/acceptance/CardContext.php
+++ b/tests/acceptance/CardContext.php
@@ -17,15 +17,17 @@ class CardContext extends BasicContext
     private $number;
     private $holder;
     private $expiration;
+    private $cvv;
 
     /**
-     * @Given a card with :number, :holder and :expiration
+     * @Given a card with :number, :holder, :expiration and :cvv
      */
-    public function aCardWithAnd($number, $holder, $expiration)
+    public function aCardWithAnd($number, $holder, $expiration, $cvv)
     {
         $this->number     = $number;
         $this->holder     = $holder;
         $this->expiration = $expiration;
+        $this->cvv        = $cvv;
     }
 
     /**
@@ -38,7 +40,8 @@ class CardContext extends BasicContext
             ->create(
                 $this->number,
                 $this->holder,
-                $this->expiration
+                $this->expiration,
+                $this->cvv
             );
     }
 
@@ -70,5 +73,13 @@ class CardContext extends BasicContext
     public function iShouldHaveTheSameCard()
     {
         assertEquals($this->createdCard->getId(), $this->queryCard->getId());
+    }
+
+    /**
+     * @And the card must be valid
+     */
+    public function theCardMustBeValid()
+    {
+        assertEquals($this->createdCard->getValid(), true);
     }
 }

--- a/tests/acceptance/features/card.feature
+++ b/tests/acceptance/features/card.feature
@@ -4,30 +4,30 @@ Feature: Cards
   Para que eu possa gerenciar cartoes de crédito
 
   Scenario Outline: Registering credit cards
-    Given a card with "<number>", "<holder>" and "<expiration>"
+    Given a card with "<number>", "<holder>", "<expiration>" and "<cvv>"
     When register the card
     Then should have a card starting with "<start>", ending with "<end>", and has "<expiration>"
-
+    And the card must be valid
     Examples:
-      |       number        |     holder    | expiration |  start | end  |
-      |  4485546331016988   |  João Silva   |    0623    | 448554 | 6988 |
-      |  5474098940693468   |  Maria Silva  |    0623    | 547409 | 3468 |
-      |  30169926530004     |  Pedro Silva  |    0623    | 301699 | 0004 |
-      |  376660303489147    |  Cesar Silva  |    0623    | 376660 | 9147 |
-      |  6062824855595083   |  Carla Silva  |    0623    | 606282 | 5083 |
-      |  6363688420875031   |  Marta Silva  |    0623    | 636368 | 5031 |
+      |       number        |     holder    | expiration | cvv |  start | end  |
+      |  4485546331016988   |  João Silva   |    0623    | 123 | 448554 | 6988 |
+      |  5474098940693468   |  Maria Silva  |    0623    | 123 | 547409 | 3468 |
+      |  30169926530004     |  Pedro Silva  |    0623    | 123 | 301699 | 0004 |
+      |  376660303489147    |  Cesar Silva  |    0623    | 123 | 376660 | 9147 |
+      |  6062824855595083   |  Carla Silva  |    0623    | 123 | 606282 | 5083 |
+      |  6363688420875031   |  Marta Silva  |    0623    | 123 | 636368 | 5031 |
 
   Scenario Outline: Registering credit cards
-    Given a card with "<number>", "<holder>" and "<expiration>"
+    Given a card with "<number>", "<holder>", "<expiration>" and "<cvv>"
     When register the card
     And query for the card
     Then should have the same card
-
+    And the card must be valid
     Examples:
-      |       number        |     holder    | expiration |
-      |  4929321265858746   |  João Silva   |    0623    |
-      |  5432256307060520   |  Maria Silva  |    0623    |
-      |  30368598412349     |  Pedro Silva  |    0623    |
-      |  346352677988113    |  Cesar Silva  |    0623    |
-      |  6062825718578307   |  Carla Silva  |    0623    |
-      |  4514164846540487   |  Marta Silva  |    0623    |
+      |       number        |     holder    | expiration | cvv |
+      |  4929321265858746   |  João Silva   |    0623    | 123 |
+      |  5432256307060520   |  Maria Silva  |    0623    | 123 |
+      |  30368598412349     |  Pedro Silva  |    0623    | 123 |
+      |  346352677988113    |  Cesar Silva  |    0623    | 123 |
+      |  6062825718578307   |  Carla Silva  |    0623    | 123 |
+      |  4514164846540487   |  Marta Silva  |    0623    | 123 |

--- a/tests/unit/Card/Request/CardCreateTest.php
+++ b/tests/unit/Card/Request/CardCreateTest.php
@@ -11,6 +11,7 @@ class CardCreateTest extends \PHPUnit_Framework_TestCase
     const CARD_NUMBER     = '4539401723324663';
     const CARD_HOLDER     = 'João Silva';
     const CARD_EXPIRATION = '0423';
+    const CARD_CVV        = 123;
 
     /**
      * @test
@@ -20,14 +21,16 @@ class CardCreateTest extends \PHPUnit_Framework_TestCase
         $cardCreate = new CardCreate(
             self::CARD_NUMBER,
             self::CARD_HOLDER,
-            self::CARD_EXPIRATION
+            self::CARD_EXPIRATION,
+            self::CARD_CVV
         );
 
         $this->assertEquals(
             [
                 'card_number'          => self::CARD_NUMBER,
                 'holder_name'          => self::CARD_HOLDER,
-                'card_expiration_date' => self::CARD_EXPIRATION
+                'card_expiration_date' => self::CARD_EXPIRATION,
+                'card_cvv'             => self::CARD_CVV
             ],
             $cardCreate->getPayload()
         );


### PR DESCRIPTION
### Descrição

Este PR tem como seu objetivo permitir que o `cardCvv` também possa ser enviado na criação de um novo cartão, porém sem fazer com que o mesmo se torne obrigatório. Por mais que essa informação não seja obrigatória para que um cartão seja criado, ainda assim a possibilidade de se passar a mesma deveria existir.

### Número da Issue

None.

### Testes Realizados

Foi validado se o `card_cvv` consta no `payload` de criação de um novo objeto `card`, assim como se um novo cartão válido é criado ao se passar o parâmetro.