### PR TITLE
add softdescriptor to boleto transaction

### DIFF
--- a/lib/Transaction/BoletoTransaction.php
+++ b/lib/Transaction/BoletoTransaction.php
@@ -31,7 +31,6 @@ class BoletoTransaction extends AbstractTransaction
      */
     protected $softDescriptor;
 
-
     /**
      * @var string
      */
@@ -90,7 +89,6 @@ class BoletoTransaction extends AbstractTransaction
     {
         return $this->softDescriptor;
     }
-
 
     /**
      * @return string

--- a/lib/Transaction/BoletoTransaction.php
+++ b/lib/Transaction/BoletoTransaction.php
@@ -29,6 +29,12 @@ class BoletoTransaction extends AbstractTransaction
     /**
      * @var string
      */
+    protected $softDescriptor;
+
+
+    /**
+     * @var string
+     */
     protected $boletoInstructions;
 
     /**
@@ -75,6 +81,16 @@ class BoletoTransaction extends AbstractTransaction
     {
         return $this->async;
     }
+
+    /**
+     * @return string
+     * @codeCoverageIgnore
+     */
+    public function getSoftDescriptor()
+    {
+        return $this->softDescriptor;
+    }
+
 
     /**
      * @return string

--- a/lib/Transaction/Request/BoletoTransactionCreate.php
+++ b/lib/Transaction/Request/BoletoTransactionCreate.php
@@ -24,7 +24,8 @@ class BoletoTransactionCreate extends TransactionCreate
         $boletoData = [
             'boleto_expiration_date' => $this->transaction->getBoletoExpirationDate(),
             'async' => $this->transaction->getAsync(),
-            'boleto_instructions' => $this->transaction->getBoletoInstructions()
+            'boleto_instructions' => $this->transaction->getBoletoInstructions(),
+            'soft_descriptor' => $this->transaction->getSoftDescriptor()
         ];
 
         return array_merge($basicData, $boletoData);

--- a/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
@@ -62,7 +62,8 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 ],
                 'metadata' => null,
                 'async' => null,
-                'boleto_instructions' => null
+                'boleto_instructions' => null,
+                'soft_descriptor' => null
             ],
             $transactionCreate->getPayload()
         );
@@ -149,7 +150,8 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 ],
                 'metadata' => null,
                 'async' => null,
-                'boleto_instructions' => null
+                'boleto_instructions' => null,
+                'soft_descriptor' => null
             ],
             $transactionCreate->getPayload()
         );

--- a/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
@@ -230,4 +230,59 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
 
         return $customerMock;
     }
+
+    /**
+     * @test
+     */
+    public function mustPayloadContainSoftDescriptor()
+    {
+
+        $customerMock = $this->getCustomerMock();
+
+        $transaction =  new BoletoTransaction(
+            [
+                'amount'                 => 1338,
+                'postback_url'           => 'example.com/postback',
+                'customer'               => $customerMock,
+                'soft_descriptor'        => "Minha loja"
+            ]
+        );
+
+        $transactionCreate = new boletoTransactionCreate (
+            $transaction
+        );
+
+        $this->assertEquals(
+            [
+                'amount'                 => 1338,
+                'payment_method'         => 'boleto',
+                'postback_url'           => 'example.com/postback',
+                'boleto_expiration_date' => null,
+                'customer' => [
+                    'name'            => 'Eduardo Nascimento',
+                    'born_at'         => '15071991',
+                    'document_number' => '10586649727',
+                    'email'           => 'eduardo@eduardo.com',
+                    'sex'             => 'M',
+                    'address' => [
+                        'street'        => 'rua teste',
+                        'street_number' => 42,
+                        'neighborhood'  => 'centro',
+                        'zipcode'       => '01227200',
+                        'complementary' => null
+                    ],
+                    'phone' => [
+                        'ddi'    => 55,
+                        'ddd'    => 15,
+                        'number' => 987523421
+                    ]
+                ],
+                'metadata' => null,
+                'async' => null,
+                'boleto_instructions' => null,
+                'soft_descriptor' => 'Minha loja'
+            ],
+            $transactionCreate->getPayload()
+        );
+    }
 }


### PR DESCRIPTION
Adiciona o campo `soft_descriptor` para transações de boleto bancário através do parâmetro `$extraAttributtes`;

PR criado por solicitação de um cliente =)