### PR TITLE
feature: add customer id to transaction and subscription payload

### DIFF
--- a/lib/Subscription/Request/SubscriptionCreate.php
+++ b/lib/Subscription/Request/SubscriptionCreate.php
@@ -78,6 +78,10 @@ abstract class SubscriptionCreate implements RequestInterface
             'postback_url' => $this->postbackUrl
         ];
 
+        if (!is_null($this->customer->getId())) {
+            $payload['customer']['id'] = $this->customer->getId();
+        }
+
         if (!is_null($this->customer->getAddress())) {
             $payload['customer']['address'] = $this->getAddresssData();
         }

--- a/lib/Transaction/Request/TransactionCreate.php
+++ b/lib/Transaction/Request/TransactionCreate.php
@@ -46,6 +46,10 @@ class TransactionCreate implements RequestInterface
             'born_at'         => $customer->getBornAt()
         ];
 
+        if (!is_null($customer->getId())) {
+            $customerData['id'] = $customer->getId();
+        }
+
         $customerData = array_merge(
             $customerData,
             $this->getCustomerAddressData($customer),

--- a/tests/acceptance/SubscriptionContext.php
+++ b/tests/acceptance/SubscriptionContext.php
@@ -53,6 +53,17 @@ class SubscriptionContext extends BasicContext
     }
 
     /**
+     * @Given retrieving an existent customer
+     * @And retrieving an existent customer
+     */
+    public function retrievingACustomer()
+    {
+        $this->customer = self::getPagarMe()
+            ->customer()
+            ->get($this->customer->getId());
+    }
+
+    /**
      * @Given a valid plan
      */
     public function aValidPlan($planName = 'Test Plan')
@@ -251,5 +262,14 @@ class SubscriptionContext extends BasicContext
             ->subscription()
             ->update($this->subscription);
         $this->iQueryForTheSubscription();
+    }
+
+    /**
+     * @Then the subscription customer id must be the same as the retrieved
+     */
+    public function theSubscriptionCustomerIdMustBeTheSameAsTheRetrieved()
+    {
+        $subscriptionCustomer = $this->subscription->getCustomer();
+        assertEquals($subscriptionCustomer->getId(), $this->customer->getId());
     }
 }

--- a/tests/acceptance/TransactionContext.php
+++ b/tests/acceptance/TransactionContext.php
@@ -42,8 +42,41 @@ class TransactionContext extends BasicContext
         $this->customer = new Customer($customerData);
     }
 
+    /**
+     * @Given an existent customer
+     */
+    public function anExistentCustomer()
+    {
+        $address = new \PagarMe\Sdk\Customer\Address(
+            [
+                'street' => 'rua teste',
+                'street_number' => 42,
+                'neighborhood' => 'centro',
+                'zipcode' => '01227200'
+            ]
+        );
 
-     /**
+        $this->customer = self::getPagarMe()
+            ->customer()
+            ->create(
+                $this->getCustomerName(),
+                $this->getCustomerEmail(),
+                $this->getCustomerDocumentNumber(),
+                $address,
+                new \PagarMe\Sdk\Customer\Phone(
+                    [
+                        'ddd' =>11,
+                        'number' =>987654321
+                    ]
+                )
+            );
+
+        $this->customer = self::getPagarMe()
+            ->customer()
+            ->get($this->customer->getId());
+    }
+
+    /**
      * @When make a credit card transaction with :arg1 and :arg2
      * @And make a credit card transaction with :amount and :installments
      */
@@ -209,7 +242,7 @@ class TransactionContext extends BasicContext
         $this->makeABoletoTransactionWith(1337);
     }
 
-     /**
+    /**
      * @Given I had multiple transactions registered
      */
     public function iHadMultipleTransactionsRegistered()
@@ -493,5 +526,14 @@ class TransactionContext extends BasicContext
     public function mustHaveStatus($status)
     {
         assertEquals($this->transaction->getStatus(), $status);
+    }
+
+    /**
+     * @Then the transaction customer must be the same retrieved
+     */
+    public function theTransactionCustomerMustBeTheSameRetrieved()
+    {
+        $transactionCustomer = $this->transaction->getCustomer();
+        assertEquals($transactionCustomer->id, $this->customer->getId());
     }
 }

--- a/tests/acceptance/features/subscription.feature
+++ b/tests/acceptance/features/subscription.feature
@@ -18,6 +18,13 @@ Feature: Subscription
     Then a subscription must be created
     And the payment method must be 'boleto'
 
+ Scenario: Create a boleto subscription with a retrieved customer
+    Given a valid customer
+    And retrieving an existent customer
+    And a valid plan
+    When make a boleto subscription
+    Then the subscription customer id must be the same as the retrieved
+
  Scenario: Get a subscription
     Given a previous created subscription
     When I query for the subscription

--- a/tests/acceptance/features/transaction.feature
+++ b/tests/acceptance/features/transaction.feature
@@ -161,3 +161,8 @@ Feature: Transaction
       |  amount  | async  |      status     |
       |   1000   | true   |    processing   |
       |   1000   | false  | waiting_payment |
+
+  Scenario: Create a boleto transaction with a retrieved customer
+    Given an existent customer
+    When make a boleto transaction with random amount and metadata
+    Then the transaction customer must be the same retrieved

--- a/tests/unit/Subscription/Request/CardSubscriptionCreateTest.php
+++ b/tests/unit/Subscription/Request/CardSubscriptionCreateTest.php
@@ -16,6 +16,7 @@ class CardSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
 
     const POSTBACK_URL   = 'http://myhost.com/postback';
 
+    const CUSTOMER_ID             = 12345;
     const CUSTOMER_NAME           = 'John Doe';
     const CUSTOMER_EMAIL          = 'john@test.com';
     const CUSTOMER_DOCUMENTNUMBER = '576981209';
@@ -53,6 +54,8 @@ class CardSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $customerMock->method('getId')
+            ->willReturn(self::CUSTOMER_ID);
         $customerMock->method('getName')
             ->willReturn(self::CUSTOMER_NAME);
         $customerMock->method('getEmail')
@@ -167,6 +170,7 @@ class CardSubscriptionCreateTest extends \PHPUnit_Framework_TestCase
             'payment_method' => self::PLAN_PAYMENT_METHOD,
             'metadata'       => $this->planMetadata(),
             'customer'       => [
+                'id'              => self::CUSTOMER_ID,
                 'name'            => self::CUSTOMER_NAME,
                 'email'           => self::CUSTOMER_EMAIL,
                 'document_number' => self::CUSTOMER_DOCUMENTNUMBER,

--- a/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
@@ -133,6 +133,54 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function mustPayloadContainCustomerId()
+    {
+        $cardMock   = $this->getCardMock();
+
+        $customer = $this->getBlankCustomerMock();
+        $customer->method('getId')->willReturn(12345);
+
+        $transaction =  new CreditCardTransaction(
+            [
+                'amount'       => 1337,
+                'card'         => $cardMock,
+                'customer'     => $customer,
+                'installments' => 1,
+                'capture'      => false,
+                'postback_url' => null
+            ]
+        );
+
+        $transactionCreate = new CreditCardTransactionCreate($transaction);
+
+        $this->assertEquals(
+            [
+                'amount'         => 1337,
+                'card_id'        => self::CARD_ID,
+                'installments'   => 1,
+                'payment_method' => 'credit_card',
+                'capture'        => false,
+                'postback_url'   => null,
+                'customer' => [
+                    'id'              => 12345,
+                    'name'            => null,
+                    'born_at'         => null,
+                    'document_number' => null,
+                    'email'           => null,
+                    'sex'             => null
+                ],
+                'metadata'        => null,
+                'soft_descriptor' => null,
+                'async'           => null
+
+            ],
+            $transactionCreate->getPayload()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function mustPayloadContainMonetarySplitRules()
     {
         $customerMock = $this->getFullCustomerMock();


### PR DESCRIPTION
### Descrição

Esse PR visa permitir que sejam enviados clientes já existentes na base de dados do Pagar.me na criação de uma nova transação ou assinatura, fazendo com que o mesmo não seja criado repetidamente (se aplica as versões v2017-07-17 e 2017-08-28 da API).

### Número da Issue

None.

### Testes Realizados

Executando o seguinte trecho de código o `customer_id` retornado na resposta deverá ser o mesmo do objeto `customer` enviado, ou seja, não criando um cliente repetido:

```php
<?php
$card = $pagarMe->card()->create(
    '4242424242424242',
    'Shagaru Magala',
    '0722'
);

$customer = $pagarMe->customer()->get(CUSTOMER_ID);

$amount = 1000;
$installments = 1;
$capture = false;
$postbackUrl = null;
$metadata = ['idProduto' => 13933139];

$transaction = $pagarMe->transaction()->creditCardTransaction(
    $amount,
    $card,
    $customer,
    $installments,
    $capture,
    $postbackUrl,
    $metadata
);
```

**EDIT:** Testes unitários e de aceitação adicionados.