### PR TITLE
Retornar os payables de uma transaction

### DIFF
--- a/lib/Plan/Plan.php
+++ b/lib/Plan/Plan.php
@@ -46,6 +46,10 @@ class Plan
      */
     private $installments;
 
+    /**
+     * @var int
+     */
+    private $invoiceReminder;
 
     /**
      * @param array $planData
@@ -155,5 +159,14 @@ class Plan
     public function getInstallments()
     {
         return $this->installments;
+    }
+
+    /**
+     * @return int
+     * @codeCoverageIgnore
+     */
+    public function getInvoiceReminder()
+    {
+        return $this->invoiceReminder;
     }
 }

--- a/lib/Plan/PlanHandler.php
+++ b/lib/Plan/PlanHandler.php
@@ -27,7 +27,8 @@ class PlanHandler extends AbstractHandler
         $trialDays = null,
         $paymentsMethods = [],
         $charges = null,
-        $installments = null
+        $installments = null,
+        $invoiceReminder = null
     ) {
         $request = new PlanCreate(
             $amount,
@@ -36,7 +37,8 @@ class PlanHandler extends AbstractHandler
             $trialDays,
             $paymentsMethods,
             $charges,
-            $installments
+            $installments,
+            $invoiceReminder
         );
 
         $response = $this->client->send($request);

--- a/lib/Plan/Request/PlanCreate.php
+++ b/lib/Plan/Request/PlanCreate.php
@@ -42,6 +42,10 @@ class PlanCreate implements RequestInterface
      */
     private $installments;
 
+    /**
+     * @var int
+     */
+    private $invoiceReminder;
 
     /**
      * @param int $amount
@@ -59,7 +63,8 @@ class PlanCreate implements RequestInterface
         $trialDays,
         $paymentsMethods,
         $charges,
-        $installments
+        $installments,
+        $invoiceReminder
     ) {
         $this->amount          = $amount;
         $this->days            = $days;
@@ -68,6 +73,7 @@ class PlanCreate implements RequestInterface
         $this->paymentsMethods = $paymentsMethods;
         $this->charges         = $charges;
         $this->installments    = $installments;
+        $this->invoiceReminder = $invoiceReminder;
     }
 
     /**
@@ -82,7 +88,8 @@ class PlanCreate implements RequestInterface
             'trial_days'       => $this->trialDays,
             'payment_methods'  => $this->paymentsMethods,
             'charges'          => $this->charges,
-            'installments'     => $this->installments
+            'installments'     => $this->installments,
+            'invoice_reminder' => $this->invoiceReminder
         ];
     }
 

--- a/lib/Plan/Request/PlanUpdate.php
+++ b/lib/Plan/Request/PlanUpdate.php
@@ -32,6 +32,7 @@ class PlanUpdate implements RequestInterface
             'name'            => $plan->getName(),
             'trial_days'      => $plan->getTrialDays(),
             'charges'         => $plan->getCharges(),
+            'invoice_reminder'=> $plan->getInvoiceReminder()
         ];
     }
 

--- a/lib/SplitRuleSerializer.php
+++ b/lib/SplitRuleSerializer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PagarMe\Sdk;
+
+use PagarMe\Sdk\SplitRule\SplitRuleCollection;
+
+trait SplitRuleSerializer
+{
+
+    /**
+     * @param \PagarMe\Sdk\SplitRule\SplitRuleCollection $splitRules
+     * @return array
+     */
+    public function getSplitRulesInfo(SplitRuleCollection $splitRules)
+    {
+        $rules = [];
+
+        foreach ($splitRules as $key => $splitRule) {
+            $rule = [
+                'recipient_id'          => $splitRule->getRecipient()->getId(),
+                'charge_processing_fee' => $splitRule->getChargeProcessingFee(),
+                'liable'                => $splitRule->getLiable()
+            ];
+
+            $rules[$key] = array_merge($rule, $this->getRuleValue($splitRule));
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @param \PagarMe\Sdk\SplitRule\SplitRule $splitRule
+     * @return array
+     */
+    public function getRuleValue($splitRule)
+    {
+        if (!is_null($splitRule->getAmount())) {
+            return ['amount' => $splitRule->getAmount()];
+        }
+
+        return ['percentage' => $splitRule->getPercentage()];
+    }
+}

--- a/lib/Transaction/Request/TransactionCapture.php
+++ b/lib/Transaction/Request/TransactionCapture.php
@@ -3,9 +3,12 @@
 namespace PagarMe\Sdk\Transaction\Request;
 
 use PagarMe\Sdk\RequestInterface;
+use PagarMe\Sdk\SplitRule\SplitRuleCollection;
 
 class TransactionCapture implements RequestInterface
 {
+    use \PagarMe\Sdk\SplitRuleSerializer;
+
     /**
      * @var int
      */
@@ -18,17 +21,23 @@ class TransactionCapture implements RequestInterface
      * @var array
      */
     protected $metadata;
+    /**
+     * @var PagarMe\Sdk\SplitRule\SplitRuleCollection
+     */
+    protected $splitRules;
 
     /**
      * @param PagarMe\Sdk\Transaction\Transaction $transaction
      * @param int $amount
      * @param array $metadata
+     * @param PagarMe\Sdk\SplitRule\SplitRuleCollection $splitRules
      */
-    public function __construct($transaction, $amount, $metadata = [])
+    public function __construct($transaction, $amount, $metadata = [], SplitRuleCollection $splitRules = null)
     {
         $this->transaction = $transaction;
         $this->amount = $amount;
         $this->metadata = $metadata;
+        $this->splitRules = $splitRules;
     }
 
     /**
@@ -44,6 +53,12 @@ class TransactionCapture implements RequestInterface
 
         if (!empty($this->metadata)) {
             $payload['metadata'] = $this->metadata;
+        }
+
+        if (!is_null($this->splitRules)) {
+            $payload['split_rules'] = $this->getSplitRulesInfo(
+                $this->splitRules
+            );
         }
 
         return $payload;

--- a/lib/Transaction/Request/TransactionCreate.php
+++ b/lib/Transaction/Request/TransactionCreate.php
@@ -11,6 +11,8 @@ use PagarMe\Sdk\Customer\Customer;
 
 class TransactionCreate implements RequestInterface
 {
+    use \PagarMe\Sdk\SplitRuleSerializer;
+
     /**
      * @var \PagarMe\Sdk\Transaction\Transaction
      */
@@ -81,40 +83,6 @@ class TransactionCreate implements RequestInterface
     public function getMethod()
     {
         return self::HTTP_POST;
-    }
-
-    /**
-     * @param \PagarMe\Sdk\SplitRule\SplitRuleCollection $splitRules
-     * @return array
-     */
-    private function getSplitRulesInfo(SplitRuleCollection $splitRules)
-    {
-        $rules = [];
-
-        foreach ($splitRules as $key => $splitRule) {
-            $rule = [
-                'recipient_id'          => $splitRule->getRecipient()->getId(),
-                'charge_processing_fee' => $splitRule->getChargeProcessingFee(),
-                'liable'                => $splitRule->getLiable()
-            ];
-
-            $rules[$key] = array_merge($rule, $this->getRuleValue($splitRule));
-        }
-
-        return $rules;
-    }
-
-    /**
-     * @param \PagarMe\Sdk\SplitRule\SplitRule $splitRule
-     * @return array
-     */
-    private function getRuleValue($splitRule)
-    {
-        if (!is_null($splitRule->getAmount())) {
-            return ['amount' => $splitRule->getAmount()];
-        }
-
-        return ['percentage' => $splitRule->getPercentage()];
     }
 
     /**

--- a/lib/Transaction/Request/TransactionPayables.php
+++ b/lib/Transaction/Request/TransactionPayables.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace PagarMe\Sdk\Transaction\Request;
+
+use PagarMe\Sdk\RequestInterface;
+
+class TransactionPayables implements RequestInterface
+{
+    /**
+     * @var int
+     */
+    protected $transactionId;
+
+    /**
+     * @param int transactionId
+     */
+    public function __construct($transactionId)
+    {
+        $this->transactionId = $transactionId;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPayload()
+    {
+        return [];
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return sprintf('transactions/%s/payables', $this->transactionId);
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return self::HTTP_GET;
+    }
+}

--- a/lib/Transaction/TransactionHandler.php
+++ b/lib/Transaction/TransactionHandler.php
@@ -17,6 +17,7 @@ use PagarMe\Sdk\BankAccount\BankAccount;
 use PagarMe\Sdk\Card\Card;
 use PagarMe\Sdk\Customer\Customer;
 use PagarMe\Sdk\Recipient\Recipient;
+use PagarMe\Sdk\SplitRule\SplitRuleCollection;
 
 class TransactionHandler extends AbstractHandler
 {
@@ -133,14 +134,16 @@ class TransactionHandler extends AbstractHandler
      * @param AbstractTransaction $transaction
      * @param int $amount
      * @param array $metadata
+     * @param \PagarMe\Sdk\SplitRule\SplitRuleCollection $splitRules
      * @return AbstractTransaction
      */
     public function capture(
         AbstractTransaction $transaction,
         $amount = null,
-        $metadata = []
+        $metadata = [],
+        SplitRuleCollection $splitRules = null
     ) {
-        $request = new TransactionCapture($transaction, $amount, $metadata);
+        $request = new TransactionCapture($transaction, $amount, $metadata, $splitRules);
         $response = $this->client->send($request);
 
         return $this->buildTransaction($response);

--- a/lib/Transaction/TransactionHandler.php
+++ b/lib/Transaction/TransactionHandler.php
@@ -4,12 +4,14 @@ namespace PagarMe\Sdk\Transaction;
 
 use PagarMe\Sdk\AbstractHandler;
 use PagarMe\Sdk\Client;
+use PagarMe\Sdk\Payable\PayableBuilder;
 use PagarMe\Sdk\Transaction\Request\CreditCardTransactionCreate;
 use PagarMe\Sdk\Transaction\Request\BoletoTransactionCreate;
 use PagarMe\Sdk\Transaction\Request\TransactionGet;
 use PagarMe\Sdk\Transaction\Request\TransactionList;
 use PagarMe\Sdk\Transaction\Request\TransactionCapture;
 use PagarMe\Sdk\Transaction\Request\TransactionEvents;
+use PagarMe\Sdk\Transaction\Request\TransactionPayables;
 use PagarMe\Sdk\Transaction\Request\CreditCardTransactionRefund;
 use PagarMe\Sdk\Transaction\Request\BoletoTransactionRefund;
 use PagarMe\Sdk\Transaction\Request\TransactionPay;
@@ -21,6 +23,7 @@ use PagarMe\Sdk\SplitRule\SplitRuleCollection;
 
 class TransactionHandler extends AbstractHandler
 {
+    use PayableBuilder;
     use TransactionBuilder;
     use \PagarMe\Sdk\Event\EventBuilder;
 
@@ -110,6 +113,26 @@ class TransactionHandler extends AbstractHandler
         $response = $this->client->send($request);
 
         return $this->buildTransaction($response);
+    }
+
+    /**
+     * @param $transactionId
+     * @return array
+     * @throws \PagarMe\Sdk\ClientException
+     */
+    public function payables($transactionId)
+    {
+        $request = new TransactionPayables($transactionId);
+
+        $response = $this->client->send($request);
+
+        $payables = [];
+
+        foreach ($response as $payableData) {
+            $payables[] = $this->buildPayable($payableData);
+        }
+
+        return $payables;
     }
 
     /**

--- a/tests/acceptance/Helper/RecipientData.php
+++ b/tests/acceptance/Helper/RecipientData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PagarMe\Acceptance\Helper;
+
+use PagarMe\Sdk\BankAccount\BankAccount;
+use PagarMe\Sdk\Recipient\Recipient;
+
+trait RecipientData
+{
+    
+    public function createRecipient()
+    {
+        $accountData = [
+            "bank_code" => "341",
+            "agencia" => "0932",
+            "conta" => "580" . rand(10, 99),
+            "conta_dv" => "5",
+            "document_number" => "26268738888",
+            "legal_name" => "API BANK ACCOUNT"
+        ];
+
+        $bankAccount = new BankAccount($accountData);
+        return self::getPagarMe()->recipient()->create($bankAccount);
+    }
+}

--- a/tests/acceptance/SplitRuleContext.php
+++ b/tests/acceptance/SplitRuleContext.php
@@ -15,6 +15,7 @@ use PagarMe\Sdk\Customer\Customer;
 class SplitRuleContext extends BasicContext
 {
     use Helper\CustomerDataProvider;
+    use Helper\RecipientData;
 
     private $customer;
     private $splitRules;
@@ -132,22 +133,5 @@ class SplitRuleContext extends BasicContext
         $countedSplitRules = count($this->transaction->getSplitRules());
         assertInternalType('int', $countedSplitRules);
         assertEquals($quantity, $countedSplitRules);
-    }
-
-    private function createRecipient()
-    {
-        $accountData = [
-            "bank_code" => "341",
-            "agencia" => "0932",
-            "conta" => "580" . rand(10, 99),
-            "conta_dv" => "5",
-            "document_number" => "26268738888",
-            "legal_name" => "API BANK ACCOUNT"
-        ];
-
-        $bankAccount = new BankAccount($accountData);
-        return self::getPagarMe()
-            ->recipient()
-            ->create($bankAccount);
     }
 }

--- a/tests/acceptance/features/transaction.feature
+++ b/tests/acceptance/features/transaction.feature
@@ -166,3 +166,11 @@ Feature: Transaction
     Given an existent customer
     When make a boleto transaction with random amount and metadata
     Then the transaction customer must be the same retrieved
+
+  Scenario: Capture a transaction with split rules
+    Given a valid customer
+    And a valid card
+    When make a authorized credit card transaction
+    Then a authorized transaction must be created
+    And capture the transaction with split rules
+    And a paid transaction must be created

--- a/tests/unit/Helper/RecipientData.php
+++ b/tests/unit/Helper/RecipientData.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PagarMe\SdkTest\Helper;
+
+use PagarMe\Sdk\BankAccount\BankAccount;
+use PagarMe\Sdk\Recipient\Recipient;
+
+trait RecipientData
+{
+    
+    public function createRecipient()
+    {
+        $accountData = [
+            "bank_code" => "341",
+            "agencia" => "0932",
+            "conta" => "580" . rand(10, 99),
+            "conta_dv" => "5",
+            "document_number" => "26268738888",
+            "legal_name" => "API BANK ACCOUNT"
+        ];
+
+        $bankAccount = new BankAccount($accountData);
+        return new Recipient([
+            "bank_account" => $bankAccount
+        ]);
+    }
+}

--- a/tests/unit/Plan/Request/PlanCreateTest.php
+++ b/tests/unit/Plan/Request/PlanCreateTest.php
@@ -21,7 +21,8 @@ class PlanCreateTest extends \PHPUnit_Framework_TestCase
             10,
             null,
             13,
-            26
+            26,
+            3
         );
 
         $this->assertEquals(self::PATH, $request->getPath());
@@ -34,7 +35,8 @@ class PlanCreateTest extends \PHPUnit_Framework_TestCase
                 'trial_days'      => 10,
                 'payment_methods' => null,
                 'charges'         => 13,
-                'installments'    => 26
+                'installments'    => 26,
+                'invoice_reminder'=> 3
             ],
             $request->getPayload()
         );

--- a/tests/unit/Plan/Request/PlanUpdateTest.php
+++ b/tests/unit/Plan/Request/PlanUpdateTest.php
@@ -9,14 +9,15 @@ class PlanUpdateTest extends \PHPUnit_Framework_TestCase
 {
     const PATH = 'plans/1406';
 
-    const ID              = 1406;
-    const AMOUNT          = 1337;
-    const DAYS            = 15;
-    const NAME            = "Plano teste";
-    const TRIAL_DAYS      = 10;
-    const PAYMENT_METHODS = null;
-    const CHARGES         = 13;
-    const INSTALLMENTS    = 26;
+    const ID                = 1406;
+    const AMOUNT            = 1337;
+    const DAYS              = 15;
+    const NAME              = "Plano teste";
+    const TRIAL_DAYS        = 10;
+    const PAYMENT_METHODS   = null;
+    const CHARGES           = 13;
+    const INSTALLMENTS      = 26;
+    const INVOICE_REMINDER  = 4;
 
     /**
      * @test
@@ -35,6 +36,7 @@ class PlanUpdateTest extends \PHPUnit_Framework_TestCase
         $planMock->method('getPaymentMethods')->willReturn(self::PAYMENT_METHODS);
         $planMock->method('getCharges')->willReturn(self::CHARGES);
         $planMock->method('getInstallments')->willReturn(self::INSTALLMENTS);
+        $planMock->method('getInvoiceReminder')->willReturn(self::INVOICE_REMINDER);
 
         $request = new PlanUpdate($planMock);
 
@@ -42,10 +44,11 @@ class PlanUpdateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(RequestInterface::HTTP_PUT, $request->getMethod());
         $this->assertEquals(
             [
-                'id'              => self::ID,
-                'name'            => self::NAME,
-                'trial_days'      => self::TRIAL_DAYS,
-                'charges'         => self::CHARGES
+                'id'                => self::ID,
+                'name'              => self::NAME,
+                'trial_days'        => self::TRIAL_DAYS,
+                'charges'           => self::CHARGES,
+                'invoice_reminder'  => self::INVOICE_REMINDER
             ],
             $request->getPayload()
         );

--- a/tests/unit/SplitRuleSerializerTest.php
+++ b/tests/unit/SplitRuleSerializerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace PagarMe\SdkTest;
+
+use PagarMe\Sdk\SplitRule\SplitRule;
+use PagarMe\Sdk\SplitRule\SplitRuleCollection;
+use PagarMe\Sdk\Recipient\Recipient;
+
+class SplitRuleSerializerTest extends \PHPUnit_Framework_TestCase
+{
+    use Helper\RecipientData;
+    use \PagarMe\Sdk\SplitRuleSerializer;
+
+    /**
+     * @test
+     */
+    public function mustSerializeSplitRule()
+    {
+        $splitRules = new SplitRuleCollection();
+        $splitRule1 = new SplitRule([
+            "percentage" => 80,
+            "recipient" => $this->createRecipient(),
+            "liable" => true,
+            "charge_processing_fee" => true,
+            "charge_remainder" => true
+        ]);
+
+        $splitRule2 = new SplitRule([
+            "percentage" => 20,
+            "recipient" => $this->createRecipient(),
+            "liable" => false,
+            "charge_processing_fee" => false,
+            "charge_remainder" => false
+        ]);
+
+        $splitRules[] = $splitRule1;
+        $splitRules[] = $splitRule2;
+
+        $this->assertEquals(
+            [
+                array(
+                    "recipient_id" => null,
+                    "charge_processing_fee" => true,
+                    "liable" => true,
+                    "percentage" => 80
+                ),
+                array(
+                    "recipient_id" => null,
+                    "charge_processing_fee" => false,
+                    "liable" => false,
+                    "percentage" => 20
+                )
+            ],
+            $this->getSplitRulesInfo($splitRules)
+        );
+    }
+}

--- a/tests/unit/Transaction/Request/TransactionPayablesTest.php
+++ b/tests/unit/Transaction/Request/TransactionPayablesTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace PagarMe\SdkTest\Transaction\Request;
+
+use PagarMe\Sdk\RequestInterface;
+use PagarMe\Sdk\Transaction\Request\TransactionPayables;
+
+class TransactionPayablesTest extends \PHPUnit_Framework_TestCase
+{
+    const PATH           = 'transactions/1337/payables';
+    const TRANSACTION_ID = 1337;
+
+    /**
+     * @test
+     */
+    public function mustPayloadBeCorrect()
+    {
+        $transactionCreate = new TransactionPayables(self::TRANSACTION_ID);
+
+        $this->assertEquals(
+            [],
+            $transactionCreate->getPayload()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mustPathBeCorrect()
+    {
+        $transactionCreate = new TransactionPayables(self::TRANSACTION_ID);
+
+        $this->assertEquals(self::PATH, $transactionCreate->getPath());
+    }
+
+    /**
+     * @test
+     */
+    public function mustMethodBeCorrect()
+    {
+        $transactionCreate = new TransactionPayables(self::TRANSACTION_ID);
+
+        $this->assertEquals(RequestInterface::HTTP_GET, $transactionCreate->getMethod());
+    }
+}


### PR DESCRIPTION
### Descrição

Tenho a necessidade de retornar todos os Payables de uma Transaction. Percebi que outros também possuem, como é o caso aqui https://github.com/pagarme/pagarme-php/issues/236

Como ficou a API:

```php
$payables = $pagarMe->transaction()->payables(1899);
```

Imaginei que essa semântica pudesse ser a correta para a forma com que a biblioteca foi arquitetada. No entanto, outra opção seria:

```php
$payables = $pagarMe->payable()->allByTransaction(1899);
```

Algo nesse sentido. Mas essa posição/decisão eu deixo pra vocês.

### Número da Issue

https://github.com/pagarme/pagarme-php/issues/236

### Testes Realizados

Segui o modelo dos testes existentes.
