### PR TITLE
Fix wrong object type after create a transaction

### DIFF
--- a/lib/Customer/CustomerBuilder.php
+++ b/lib/Customer/CustomerBuilder.php
@@ -22,4 +22,31 @@ trait CustomerBuilder
 
         return new Customer(get_object_vars($customerData));
     }
+
+    /**
+     * @param array $customerData
+     * @return Customer
+     */
+    private function buildCustomerFromResponse($customerData, $addressData, $phoneData)
+    {
+        if (is_null($customerData) || $customerData == new \stdClass()) {
+            return null;
+        }
+
+        if (!is_null($addressData)) {
+            $customerData->address = new Address(
+                get_object_vars($addressData)
+            );
+        }
+
+        if (!is_null($phoneData)) {
+            $customerData->phone = new Phone($phoneData);
+        }
+
+        $customerData->date_created = new \DateTime(
+            $customerData->date_created
+        );
+
+        return new Customer(get_object_vars($customerData));
+    }
 }

--- a/lib/Transaction/TransactionBuilder.php
+++ b/lib/Transaction/TransactionBuilder.php
@@ -6,6 +6,7 @@ trait TransactionBuilder
 {
     use \PagarMe\Sdk\SplitRule\SplitRuleBuilder;
     use \PagarMe\Sdk\Customer\CustomerBuilder;
+    use \PagarMe\Sdk\Card\CardBuilder;
 
     /**
      * @param array transactionData
@@ -35,6 +36,10 @@ trait TransactionBuilder
                 (object) $transactionData->address,
                 (object) $transactionData->phone
             );
+        }
+
+        if (isset($transactionData->card)) {
+            $transactionData->card = $this->buildCard((object) $transactionData->card);
         }
 
         if ($transactionData->payment_method == BoletoTransaction::PAYMENT_METHOD) {

--- a/lib/Transaction/TransactionBuilder.php
+++ b/lib/Transaction/TransactionBuilder.php
@@ -5,6 +5,7 @@ namespace PagarMe\Sdk\Transaction;
 trait TransactionBuilder
 {
     use \PagarMe\Sdk\SplitRule\SplitRuleBuilder;
+    use \PagarMe\Sdk\Customer\CustomerBuilder;
 
     /**
      * @param array transactionData
@@ -23,9 +24,18 @@ trait TransactionBuilder
         $transactionData->date_created = new \DateTime(
             $transactionData->date_created
         );
+
         $transactionData->date_updated = new \DateTime(
             $transactionData->date_updated
         );
+
+        if (isset($transactionData->customer)) {
+            $transactionData->customer = $this->buildCustomerFromResponse(
+                (object) $transactionData->customer,
+                (object) $transactionData->address,
+                (object) $transactionData->phone
+            );
+        }
 
         if ($transactionData->payment_method == BoletoTransaction::PAYMENT_METHOD) {
             $transactionData->boleto_expiration_date = new \DateTime(

--- a/tests/acceptance/BulkAnticipationContext.php
+++ b/tests/acceptance/BulkAnticipationContext.php
@@ -68,6 +68,12 @@ class BulkAnticipationContext extends BasicContext
 
         $paymentDate = new \Datetime($paymentDate);
 
+        $weekday = $paymentDate->format('w');
+
+        if (in_array($weekday, [0,6])) {
+            $paymentDate->modify('+2 days');
+        }
+
         $paymentDate->setTime(0, 0, 0);
 
         $this->expectedPaymentDate = $paymentDate;

--- a/tests/acceptance/TransactionContext.php
+++ b/tests/acceptance/TransactionContext.php
@@ -590,7 +590,7 @@ class TransactionContext extends BasicContext
     public function theTransactionCustomerMustBeTheSameRetrieved()
     {
         $transactionCustomer = $this->transaction->getCustomer();
-        assertEquals($transactionCustomer->id, $this->customer->getId());
+        assertEquals($transactionCustomer->getId(), $this->customer->getId());
     }
 
     private function createValidSplitRule()

--- a/tests/unit/Customer/CustomerBuilderTest.php
+++ b/tests/unit/Customer/CustomerBuilderTest.php
@@ -18,4 +18,34 @@ class CustomerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PagarMe\Sdk\Customer\Customer', $customer);
         $this->assertInstanceOf('\DateTime', $customer->getDateCreated());
     }
+
+    /**
+     * @test
+     */
+    public function mustCreateCustomerCorrectlyFromResponse()
+    {
+
+        $response = '{"phone":{"object":"phone","ddi":"55","ddd":"11","number":"987654321","id":121118},"address":{"object":"address","street":"R.Dr.GeraldoCamposMoreira","complementary":null,"street_number":"240","neighborhood":"CidadeMonções","city":"SãoPaulo","state":"SP","zipcode":"04571020","country":"Brasil","id":117699},"customer":{"object":"customer","id":76758,"external_id":null,"type":null,"country":null,"document_number":"18152564000105","document_type":"cnpj","name":"AardvarkdaSilva","email":"aardvark.silva@gmail.com","phones":null,"born_at":"1985-11-02T03:00:00.000Z","birthday":null,"gender":"M","date_created":"2016-06-29T16:18:23.544Z","documents":[]}}';
+
+        $data = json_decode($response);
+
+        $customer = $this->buildCustomerFromResponse($data->customer, $data->address, $data->phone);
+
+        $this->assertInstanceOf('PagarMe\Sdk\Customer\Customer', $customer);
+        $this->assertInstanceOf('\DateTime', $customer->getDateCreated());
+    }
+
+    /**
+     * @test
+     */
+    public function mustNotCreateCustomerFromResponse()
+    {
+        $response = '{"phone":{"object":"phone","ddi":"55","ddd":"11","number":"987654321","id":121118},"address":{"object":"address","street":"R.Dr.GeraldoCamposMoreira","complementary":null,"street_number":"240","neighborhood":"CidadeMonções","city":"SãoPaulo","state":"SP","zipcode":"04571020","country":"Brasil","id":117699},"customer":null}';
+
+        $data = json_decode($response);
+
+        $customer = $this->buildCustomerFromResponse($data->customer, $data->address, $data->phone);
+
+        $this->assertNull($customer);
+    }
 }


### PR DESCRIPTION
### Descrição

After create a transaction the Sdk builds an object transaction with the API response, but this object have `Customer` and `Card` as a `stdClass`. This PR fix this building the correct `Customer` and `Card` for each one.

### Número da Issue

This closes #249, closes #216 and closes #199 

### Testes Realizados

<!Descreva aqui todos os detalhes realizados para assegurar o Pull Request. Coloque todos os dados possíveis: versões dos recursos, módulos extras adicionados ao teste :)>

<!NÃO SE ESQUEÇA DE: Marcar um dos desenvolvedores do Pagar.me para review.>
