### PR TITLE
bulkanticipation: fix bulk anticipations tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - '7.0'
 before_script:
   - mkdir -p build/logs
+  - composer clear-cache
   - composer config --global github-protocols https
   - composer install --no-interaction --prefer-dist --dev
   - composer require satooshi/php-coveralls:* --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - '7.0'
 before_script:
   - mkdir -p build/logs
+  - composer config --global github-protocols https
   - composer install --no-interaction --prefer-dist --dev
   - composer require satooshi/php-coveralls:* --dev
 script:

--- a/tests/acceptance/BulkAnticipationContext.php
+++ b/tests/acceptance/BulkAnticipationContext.php
@@ -71,7 +71,7 @@ class BulkAnticipationContext extends BasicContext
         $weekday = $paymentDate->format('w');
 
         if (in_array($weekday, [0,6])) {
-            $paymentDate->modify('+2 days');
+            $paymentDate = new \Datetime('+3 days');
         }
 
         $paymentDate->setTime(0, 0, 0);


### PR DESCRIPTION
### Descrição

The bulk anticipation tests fails in some days of the week because it
count +5 days and +6 days from current date time, and the anticipation
must be in a business day. This PR fix this by validating the week day
and changing the count if the day is a weekend.

This PR also fix some Github authentication errors by changing composer config and clearing cache.

### Número da Issue


### Testes Realizados
