### PR TITLE
Aceitar parâmetros extras ao obter uma lista de transações

### DIFF
--- a/lib/Transaction/Request/TransactionList.php
+++ b/lib/Transaction/Request/TransactionList.php
@@ -17,13 +17,20 @@ class TransactionList implements RequestInterface
     private $count;
 
     /**
-     * @param int $page
-     * @param int $count
+     * @var array
      */
-    public function __construct($page, $count)
+    private $extraParameters;
+
+    /**
+     * @param $page
+     * @param $count
+     * @param array $extraParameters
+     */
+    public function __construct($page, $count, array $extraParameters = [])
     {
         $this->page  = $page;
         $this->count = $count;
+        $this->extraParameters = $extraParameters;
     }
 
     /**
@@ -31,10 +38,10 @@ class TransactionList implements RequestInterface
      */
     public function getPayload()
     {
-        return [
+        return array_merge([
             'page'  => $this->page,
             'count' => $this->count,
-        ];
+        ], $this->extraParameters);
     }
 
     /**

--- a/lib/Transaction/TransactionHandler.php
+++ b/lib/Transaction/TransactionHandler.php
@@ -136,13 +136,14 @@ class TransactionHandler extends AbstractHandler
     }
 
     /**
-     * @param int $page
-     * @param int $count
+     * @param null $page
+     * @param null $count
+     * @param array $extraParameters
      * @return array
      */
-    public function getList($page = null, $count = null)
+    public function getList($page = null, $count = null, array $extraParameters = [])
     {
-        $request = new TransactionList($page, $count);
+        $request = new TransactionList($page, $count, $extraParameters);
         $response = $this->client->send($request);
 
         $transactions = [];

--- a/tests/unit/Transaction/Request/TransactionListTest.php
+++ b/tests/unit/Transaction/Request/TransactionListTest.php
@@ -2,9 +2,8 @@
 
 namespace PagarMe\SdkTest\Transaction\Request;
 
-use PagarMe\Sdk\Transaction\Request\TransactionList;
-use PagarMe\Sdk\Transaction\CreditCardTransaction;
 use PagarMe\Sdk\RequestInterface;
+use PagarMe\Sdk\Transaction\Request\TransactionList;
 
 class TransactionListTest extends \PHPUnit_Framework_TestCase
 {
@@ -13,11 +12,12 @@ class TransactionListTest extends \PHPUnit_Framework_TestCase
     public function paginationProvider()
     {
         return [
-            [null, null],
-            [2, null],
-            [1, 5],
-            [4, 10],
-            [7, 20],
+            [null, null, []],
+            [null, null, ['status' => 'waiting_payment']],
+            [2, null, ['status' => 'waiting_payment']],
+            [1, 5, []],
+            [4, 10, ['card_holder_name' => 'foo']],
+            [7, 20, []],
         ];
     }
 
@@ -25,15 +25,14 @@ class TransactionListTest extends \PHPUnit_Framework_TestCase
      * @dataProvider paginationProvider
      * @test
      */
-    public function mustPayloadBeCorrect($page, $items)
+    public function mustPayloadBeCorrect($page, $items, array $extraParameters = [])
     {
-        $transactionCreate = new TransactionList($page, $items);
+        $transactionCreate = new TransactionList($page, $items, $extraParameters);
 
-        $this->assertEquals(
-            [
-                'page'  => $page,
-                'count' => $items
-            ],
+        $this->assertEquals(array_merge([
+            'page'  => $page,
+            'count' => $items
+        ], $extraParameters),
             $transactionCreate->getPayload()
         );
     }


### PR DESCRIPTION
Atualmente, para obter uma lista de transações, temos a seguinte interface:

```php
$transactionList = $pagarMe->transaction()->getList($page, $count);
```

No entanto, eu preciso, para uma de minhas aplicações, filtrar esse resultado, por exemplo, pelo `status` da transação.

Esse pull request adiciona um terceiro parâmetro `$extraParameters = []` que aceita filtros adicionais. Então, dessa forma, eu consigo, por exemplo, retornar transações que possuam o status `refunded`:

```php
$transactionList = $pagarMe->transaction()->getList(null, 20, ['status' => 'refunded']);
```

O que acham dessa abordagem?

Essa alteração não quebra a implementação atual. Alterei os testes unitários.

Só não tive tempo de criar testes de aceitação. Na realidade, acho que atualmente não existe nenhum teste de aceitação para esse método `getList()` de `TransactionHandler`.
