### PR TITLE
client: pass the timeout parameter to Client

### DIFF
--- a/lib/PagarMe.php
+++ b/lib/PagarMe.php
@@ -140,12 +140,12 @@ class PagarMe
                     'base_url' => 'https://api.pagar.me/1/',
                     'base_uri' => 'https://api.pagar.me/1/',
                     'defaults' => [
-                        'headers' => $headers,
-                        'timeout' => $timeout
+                        'headers' => $headers
                     ]
                 ]
             ),
-            $apiKey
+            $apiKey,
+            $timeout
         );
     }
 


### PR DESCRIPTION
### Descrição

When the SDK is instantiated the timeout parameter is not passed to the
Client and the method send utilize this parameter, without it, the
timeout will always be null, because the GuzzleClient timeout is always
overwrited.

### Testes Realizados

No tests implemented.
