### PR TITLE
transaction: add optional address data on transaction payload

### DIFF
--- a/lib/Transaction/Request/TransactionCreate.php
+++ b/lib/Transaction/Request/TransactionCreate.php
@@ -108,7 +108,10 @@ class TransactionCreate implements RequestInterface
                 'street_number' => $address->getStreetNumber(),
                 'complementary' => $address->getComplementary(),
                 'neighborhood'  => $address->getNeighborhood(),
-                'zipcode'       => $address->getZipcode()
+                'zipcode'       => $address->getZipcode(),
+                'city'          => $address->getCity(),
+                'state'         => $address->getState(),
+                'country'       => $address->getCountry()
             ]
         ];
     }

--- a/tests/acceptance/CardContext.php
+++ b/tests/acceptance/CardContext.php
@@ -76,7 +76,7 @@ class CardContext extends BasicContext
     }
 
     /**
-     * @And the card must be valid
+     * @Then the card must be valid
      */
     public function theCardMustBeValid()
     {

--- a/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
@@ -54,7 +54,10 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                         'street_number' => 42,
                         'neighborhood'  => 'centro',
                         'zipcode'       => '01227200',
-                        'complementary' => null
+                        'complementary' => null,
+                        'city'          => null,
+                        'state'         => null,
+                        'country'       => null
                     ],
                     'phone' => [
                         'ddi'    => 55,
@@ -100,7 +103,10 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                         'street_number' => 42,
                         'neighborhood'  => 'centro',
                         'zipcode'       => '01227200',
-                        'complementary' => null
+                        'complementary' => null,
+                        'city'          => null,
+                        'state'         => null,
+                        'country'       => null
                     ],
                     'phone' => [
                         'ddi'    => 55,
@@ -176,7 +182,10 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                         'street_number' => 42,
                         'neighborhood'  => 'centro',
                         'zipcode'       => '01227200',
-                        'complementary' => null
+                        'complementary' => null,
+                        'city'          => null,
+                        'state'         => null,
+                        'country'       => null
                     ],
                     'phone' => [
                         'ddi'    => 55,
@@ -324,7 +333,10 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                         'street_number' => 42,
                         'neighborhood'  => 'centro',
                         'zipcode'       => '01227200',
-                        'complementary' => null
+                        'complementary' => null,
+                        'city'          => null,
+                        'state'         => null,
+                        'country'       => null
                     ],
                     'phone' => [
                         'ddi'    => 55,

--- a/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
@@ -76,7 +76,10 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                         'street_number' => 42,
                         'neighborhood'  => 'centro',
                         'zipcode'       => '01227200',
-                        'complementary' => null
+                        'complementary' => null,
+                        'city'          => 'São Paulo',
+                        'state'         => 'SP',
+                        'country'       => 'Brazil'
                     ],
                     'phone' => [
                         'ddi'    => 55,
@@ -132,7 +135,17 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                     'born_at'         => null,
                     'document_number' => null,
                     'email'           => null,
-                    'sex'             => null
+                    'sex'             => null,
+                    'address' => [
+                        'street'        => null,
+                        'street_number' => null,
+                        'neighborhood'  => null,
+                        'zipcode'       => null,
+                        'complementary' => null,
+                        'city'          => null,
+                        'state'         => null,
+                        'country'       => null
+                    ]
                 ],
                 'metadata'        => null,
                 'soft_descriptor' => null,
@@ -183,7 +196,17 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                     'born_at'         => null,
                     'document_number' => null,
                     'email'           => null,
-                    'sex'             => null
+                    'sex'             => null,
+                    'address' => [
+                        'street'        => null,
+                        'street_number' => null,
+                        'neighborhood'  => null,
+                        'zipcode'       => null,
+                        'complementary' => null,
+                        'city'          => null,
+                        'state'         => null,
+                        'country'       => null
+                    ]
                 ],
                 'metadata'        => null,
                 'soft_descriptor' => null,
@@ -232,7 +255,17 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                     'born_at'         => null,
                     'document_number' => null,
                     'email'           => null,
-                    'sex'             => null
+                    'sex'             => null,
+                    'address' => [
+                        'street'        => null,
+                        'street_number' => null,
+                        'neighborhood'  => null,
+                        'zipcode'       => null,
+                        'complementary' => null,
+                        'city'          => null,
+                        'state'         => null,
+                        'country'       => null
+                    ]
                 ],
                 'metadata'        => null,
                 'soft_descriptor' => null,
@@ -299,7 +332,10 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                         'street_number' => 42,
                         'neighborhood'  => 'centro',
                         'zipcode'       => '01227200',
-                        'complementary' => null
+                        'complementary' => null,
+                        'city'          => 'São Paulo',
+                        'state'         => 'SP',
+                        'country'       => 'Brazil'
                     ],
                     'phone' => [
                         'ddi'    => 55,
@@ -386,7 +422,10 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                         'street_number' => 42,
                         'neighborhood'  => 'centro',
                         'zipcode'       => '01227200',
-                        'complementary' => null
+                        'complementary' => null,
+                        'city'          => 'São Paulo',
+                        'state'         => 'SP',
+                        'country'       => 'Brazil'
                     ],
                     'phone' => [
                         'ddi'    => 55,
@@ -492,7 +531,10 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                         'street_number' => 42,
                         'neighborhood'  => 'centro',
                         'zipcode'       => '01227200',
-                        'complementary' => null
+                        'complementary' => null,
+                        'city'          => 'São Paulo',
+                        'state'         => 'SP',
+                        'country'       => 'Brazil'
                     ],
                     'phone' => [
                         'ddi'    => 55,
@@ -600,7 +642,11 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'street'        => 'rua teste',
                 'street_number' => 42,
                 'neighborhood'  => 'centro',
-                'zipcode'       => '01227200'
+                'zipcode'       => '01227200',
+                'complementary' => null,
+                'city'          => 'São Paulo',
+                'state'         => 'SP',
+                'country'       => 'Brazil'
             ]
         );
         $customerMock->method('getPhone')->willReturn(
@@ -625,7 +671,18 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
         $customerMock->method('getEmail')->willReturn(null);
         $customerMock->method('getGender')->willReturn(null);
         $customerMock->method('getName')->willReturn(null);
-        $customerMock->method('getAddress')->willReturn(null);
+        $customerMock->method('getAddress')->willReturn(
+            [
+                'street'        => null,
+                'street_number' => null,
+                'neighborhood'  => null,
+                'zipcode'       => null,
+                'complementary' => null,
+                'city'          => null,
+                'state'         => null,
+                'country'       => null
+            ]
+        );
         $customerMock->method('getPhone')->willReturn(null);
 
         return $customerMock;


### PR DESCRIPTION
### Descrição

Esse PR tem como objetivo adicionar os parâmetros `city`, `state` e `country` no payload das transações. Isso se torna necessário pois caso o cliente tenha a opção "Verificação de CEP" desabilitada em sua conta, esses dados não são auto-completados e se tornam necessários para que a transação seja criada com sucesso.

### Número da Issue

None.

### Testes Realizados

Testes unitários realizados para assegurar que as informações adicionadas realmente constam no payload da transação.

<!NÃO SE ESQUEÇA DE: Marcar um dos desenvolvedores do Pagar.me para review.>
