### PR TITLE
Add reference key to transactions objects

### DIFF
--- a/lib/Transaction/AbstractTransaction.php
+++ b/lib/Transaction/AbstractTransaction.php
@@ -25,6 +25,11 @@ abstract class AbstractTransaction
     /**
      * @var string
      */
+    protected $referenceKey;
+
+    /**
+     * @var string
+     */
     protected $status;
 
     /**
@@ -172,6 +177,11 @@ abstract class AbstractTransaction
     public function getId()
     {
         return $this->id;
+    }
+
+    public function getReferenceKey()
+    {
+        return $this->referenceKey;
     }
 
     /**

--- a/lib/Transaction/Request/TransactionCreate.php
+++ b/lib/Transaction/Request/TransactionCreate.php
@@ -37,7 +37,8 @@ class TransactionCreate implements RequestInterface
             'amount'         => $this->transaction->getAmount(),
             'payment_method' => $this->transaction->getPaymentMethod(),
             'postback_url'   => $this->transaction->getPostbackUrl(),
-            'metadata' => $this->transaction->getMetadata()
+            'metadata' => $this->transaction->getMetadata(),
+            'reference_key' => $this->transaction->getReferenceKey()
         ];
 
         $customerData = [

--- a/tests/unit/CaseConverterTest.php
+++ b/tests/unit/CaseConverterTest.php
@@ -8,6 +8,7 @@ class CaseConverterTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['some_string', 'SomeString'],
+            ['SomeString', 'SomeString'],
             ['string', 'String'],
             ['another_string', 'AnotherString'],
             ['string_with_Upper', 'StringWithUpper'],
@@ -33,6 +34,7 @@ class CaseConverterTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['some_string', 'someString'],
+            ['someString', 'someString'],
             ['string', 'string'],
             ['another_string', 'AnotherString'],
             ['tring_with_Upper', 'stringWithUpper'],

--- a/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
@@ -149,7 +149,7 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'customer'               => $customerMock,
                 'boleto_expiration_date' => $expirationDate,
                 'split_rules'            => $rules,
-                'referenceKey'           => null
+                'reference_key'           => null
             ]
         );
 
@@ -301,7 +301,7 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'postback_url'           => 'example.com/postback',
                 'customer'               => $customerMock,
                 'soft_descriptor'        => "Minha loja",
-                'referenceKey'           => null
+                'reference_key'           => null
             ]
         );
 

--- a/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/BoletoTransactionCreateTest.php
@@ -11,6 +11,8 @@ use PagarMe\Sdk\RequestInterface;
 
 class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
 {
+    use FakeReferenceKey;
+
     const PATH   = 'transactions';
 
     const CARD_ID = 1;
@@ -20,9 +22,9 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
         $customer = $this->getCustomerMock();
 
         return [
-            [null],
-            [date('Y-m-d', strtotime("tomorrow"))],
-            [date('Y-m-d', strtotime("+15 days"))]
+            [null, null],
+            [date('Y-m-d', strtotime("tomorrow")), $this->getFakeReferenceKey()],
+            [date('Y-m-d', strtotime("+15 days")), null]
         ];
     }
 
@@ -63,7 +65,55 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'metadata' => null,
                 'async' => null,
                 'boleto_instructions' => null,
-                'soft_descriptor' => null
+                'soft_descriptor' => null,
+                'reference_key' => null
+            ],
+            $transactionCreate->getPayload()
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider boletoOptions
+     */
+    public function mustContainsTheRightReferenceKey(
+        $expirationDate,
+        $referenceKey
+    )
+    {
+        $transaction =  $this->createTransaction($expirationDate);
+        $transactionCreate = new BoletoTransactionCreate($transaction);
+
+        $this->assertEquals(
+            [
+                'amount'                 => 1337,
+                'payment_method'         => 'boleto',
+                'postback_url'           => 'example.com/postback',
+                'boleto_expiration_date' => $expirationDate,
+                'customer' => [
+                    'name'            => 'Eduardo Nascimento',
+                    'born_at'         => '15071991',
+                    'document_number' => '10586649727',
+                    'email'           => 'eduardo@eduardo.com',
+                    'sex'             => 'M',
+                    'address' => [
+                        'street'        => 'rua teste',
+                        'street_number' => 42,
+                        'neighborhood'  => 'centro',
+                        'zipcode'       => '01227200',
+                        'complementary' => null
+                    ],
+                    'phone' => [
+                        'ddi'    => 55,
+                        'ddd'    => 15,
+                        'number' => 987523421
+                    ]
+                ],
+                'metadata' => null,
+                'async' => null,
+                'boleto_instructions' => null,
+                'soft_descriptor' => null,
+                'reference_key' => null
             ],
             $transactionCreate->getPayload()
         );
@@ -98,7 +148,8 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'postback_url'           => 'example.com/postback',
                 'customer'               => $customerMock,
                 'boleto_expiration_date' => $expirationDate,
-                'split_rules'            => $rules
+                'split_rules'            => $rules,
+                'referenceKey'           => null
             ]
         );
 
@@ -151,7 +202,8 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'metadata' => null,
                 'async' => null,
                 'boleto_instructions' => null,
-                'soft_descriptor' => null
+                'soft_descriptor' => null,
+                'reference_key' => null
             ],
             $transactionCreate->getPayload()
         );
@@ -185,16 +237,20 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(RequestInterface::HTTP_POST, $transactionCreate->getMethod());
     }
 
-    private function createTransaction($expirationDate)
+    private function createTransaction(
+        $expirationDate,
+        $referenceKey = null
+    )
     {
         $customerMock = $this->getCustomerMock();
 
         $transaction =  new BoletoTransaction(
             [
                 'amount'                 => 1337,
-                'postback_url'          => 'example.com/postback',
+                'postback_url'           => 'example.com/postback',
                 'customer'               => $customerMock,
-                'boleto_expiration_date' => $expirationDate
+                'boleto_expiration_date' => $expirationDate,
+                'reference_key' => $referenceKey
             ]
         );
 
@@ -244,7 +300,8 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'amount'                 => 1338,
                 'postback_url'           => 'example.com/postback',
                 'customer'               => $customerMock,
-                'soft_descriptor'        => "Minha loja"
+                'soft_descriptor'        => "Minha loja",
+                'referenceKey'           => null
             ]
         );
 
@@ -280,7 +337,8 @@ class BoletoTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'metadata' => null,
                 'async' => null,
                 'boleto_instructions' => null,
-                'soft_descriptor' => 'Minha loja'
+                'soft_descriptor' => 'Minha loja',
+                'reference_key' => null
             ],
             $transactionCreate->getPayload()
         );

--- a/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
@@ -113,7 +113,7 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'installments' => $installments,
                 'capture'      => $capture,
                 'postbackUrl'  => $postbackUrl,
-                'referenceKey' => null
+                'reference_key' => null
             ]
         );
 
@@ -163,8 +163,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'customer'     => $customerMock,
                 'installments' => $installments,
                 'capture'      => $capture,
-                'postbackUrl'  => $postbackUrl,
-                'referenceKey' => $referenceKey
+                'postback_url'  => $postbackUrl,
+                'reference_key' => $referenceKey
             ]
         );
 
@@ -212,7 +212,7 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'installments' => 1,
                 'capture'      => false,
                 'postback_url' => null,
-                'referenceKey' => null
+                'reference_key' => null
             ]
         );
 
@@ -274,7 +274,7 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'capture'      => false,
                 'postback_url' => null,
                 'split_rules'  => $rules,
-                'referenceKey' => null
+                'reference_key' => null
             ]
         );
 
@@ -466,8 +466,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'customer'     => $customerMock,
                 'installments' => $installments,
                 'capture'      => $capture,
-                'postbackUrl'  => $postbackUrl,
-                'referenceKey' => null
+                'postback_url'  => $postbackUrl,
+                'reference_key' => null
             ]
         );
 
@@ -562,8 +562,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'customer'       => $customerMock,
                 'installments'   => $installments,
                 'capture'        => $capture,
-                'postbackUrl'    => $postbackUrl,
-                'softDescriptor' => $softDescriptor,
+                'postback_url'    => $postbackUrl,
+                'soft_descriptor' => $softDescriptor,
                 'async'          => $async,
             ]
         );

--- a/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/CreditCardTransactionCreateTest.php
@@ -11,10 +11,20 @@ use PagarMe\Sdk\RequestInterface;
 
 class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
 {
+    use FakeReferenceKey;
+
     const PATH   = 'transactions';
 
     const CARD_ID   = 1;
     const CARD_HASH = 'FC1mH7XLFU5fjPAzDsP0ogeAQh3qXRpHzkIrgDz64lITBUGwio67zm';
+
+    public function referenceKeyProvider()
+    {
+        return [
+            [1, true, null, null],
+            [1, true, null, $this->getFakeReferenceKey()],
+        ];
+    }
 
     public function installmentsProvider()
     {
@@ -76,7 +86,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 ],
                 'metadata'        => null,
                 'soft_descriptor' => $softDescriptor,
-                'async'           => $async
+                'async'           => $async,
+                'reference_key'   => null
             ],
             $transactionCreate->getPayload()
         );
@@ -101,7 +112,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'customer'     => $customerMock,
                 'installments' => $installments,
                 'capture'      => $capture,
-                'postbackUrl'  => $postbackUrl
+                'postbackUrl'  => $postbackUrl,
+                'referenceKey' => null
             ]
         );
 
@@ -124,7 +136,59 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 ],
                 'metadata'        => null,
                 'soft_descriptor' => null,
-                'async'           => null
+                'async'           => null,
+                'reference_key'   => null
+            ],
+            $transactionCreate->getPayload()
+        );
+    }
+
+    /**
+     * @dataProvider referenceKeyProvider
+     * @test
+     */
+    public function mustContainsTheRightReferenceKey(
+        $installments,
+        $capture,
+        $postbackUrl,
+        $referenceKey
+    ) {
+        $customerMock = $this->getBlankCustomerMock();
+        $cardMock     = $this->getCardMock();
+
+        $transaction =  new CreditCardTransaction(
+            [
+                'amount'       => 1337,
+                'card'         => $cardMock,
+                'customer'     => $customerMock,
+                'installments' => $installments,
+                'capture'      => $capture,
+                'postbackUrl'  => $postbackUrl,
+                'referenceKey' => $referenceKey
+            ]
+        );
+
+        $transactionCreate = new CreditCardTransactionCreate($transaction);
+
+        $this->assertEquals(
+            [
+                'amount'         => 1337,
+                'card_id'        => self::CARD_ID,
+                'installments'   => $installments,
+                'payment_method' => 'credit_card',
+                'capture'        => $capture,
+                'postback_url'   => $postbackUrl,
+                'customer' => [
+                    'name'            => null,
+                    'born_at'         => null,
+                    'document_number' => null,
+                    'email'           => null,
+                    'sex'             => null
+                ],
+                'metadata'        => null,
+                'soft_descriptor' => null,
+                'async'           => null,
+                'reference_key'   => $referenceKey
             ],
             $transactionCreate->getPayload()
         );
@@ -147,7 +211,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'customer'     => $customer,
                 'installments' => 1,
                 'capture'      => false,
-                'postback_url' => null
+                'postback_url' => null,
+                'referenceKey' => null
             ]
         );
 
@@ -171,8 +236,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 ],
                 'metadata'        => null,
                 'soft_descriptor' => null,
-                'async'           => null
-
+                'async'           => null,
+                'reference_key'   => null
             ],
             $transactionCreate->getPayload()
         );
@@ -208,7 +273,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'installments' => 1,
                 'capture'      => false,
                 'postback_url' => null,
-                'split_rules'  => $rules
+                'split_rules'  => $rules,
+                'referenceKey' => null
             ]
         );
 
@@ -257,7 +323,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 ],
                 'metadata'        => null,
                 'soft_descriptor' => null,
-                'async'           => null
+                'async'           => null,
+                'reference_key'   => null
             ],
             $transactionCreate->getPayload()
         );
@@ -287,13 +354,14 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
 
         $transaction =  new CreditCardTransaction(
             [
-                'amount'       => 1337,
-                'card'         => $cardMock,
-                'customer'     => $customerMock,
-                'installments' => 1,
-                'capture'      => false,
-                'postback_url' => null,
-                'split_rules'  => $rules
+                'amount'        => 1337,
+                'card'          => $cardMock,
+                'customer'      => $customerMock,
+                'installments'  => 1,
+                'capture'       => false,
+                'postback_url'  => null,
+                'split_rules'   => $rules,
+                'reference_key' => null
             ]
         );
 
@@ -342,7 +410,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 ],
                 'metadata'        => null,
                 'soft_descriptor' => null,
-                'async'           => null
+                'async'           => null,
+                'reference_key'   => null
             ],
             $transactionCreate->getPayload()
         );
@@ -397,7 +466,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'customer'     => $customerMock,
                 'installments' => $installments,
                 'capture'      => $capture,
-                'postbackUrl'  => $postbackUrl
+                'postbackUrl'  => $postbackUrl,
+                'referenceKey' => null
             ]
         );
 
@@ -432,7 +502,8 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 ],
                 'metadata'        => null,
                 'soft_descriptor' => null,
-                'async'           => null
+                'async'           => null,
+                'reference_key'   => null
             ],
             $transactionCreate->getPayload()
         );
@@ -493,7 +564,7 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
                 'capture'        => $capture,
                 'postbackUrl'    => $postbackUrl,
                 'softDescriptor' => $softDescriptor,
-                'async'          => $async
+                'async'          => $async,
             ]
         );
 
@@ -559,4 +630,5 @@ class CreditCardTransactionCreateTest extends \PHPUnit_Framework_TestCase
 
         return $customerMock;
     }
+
 }

--- a/tests/unit/Transaction/Request/FakeReferenceKey.php
+++ b/tests/unit/Transaction/Request/FakeReferenceKey.php
@@ -1,0 +1,16 @@
+<?php
+namespace PagarMe\SdkTest\Transaction\Request;
+
+/**
+ * Trait used to generate a fake reference key
+ */
+trait FakeReferenceKey
+{
+    /**
+     * @return string
+     */
+    public function getFakeReferenceKey()
+    {
+        return md5('my-reference-key');
+    }
+}


### PR DESCRIPTION
### Description

Add the `reference_key` attribute `AbstractTransactions`. That will be
usefull because this attribute avoid transactions duplication
accidentally. This attribute should have an unique value and has 20
caracters at least.

### Tests

Unit tests to validate the payload
