### PR TITLE
Remove git hook from project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,4 @@
 {
-    "repositories" : [
-        {
-            "type" : "vcs",
-            "url" : "https://github.com/pagarme/git-hooks.git"
-        }
-    ],
     "name": "pagarme/pagarme-php",
     "description": "Pagar.Me PHP Library",
     "type": "lib",
@@ -25,11 +19,9 @@
     "require-dev": {
         "ext-mbstring": "*",
         "phpunit/phpunit": "^4.8",
-        "pagarme/git-hooks": "dev-master",
         "behat/mink-extension": "^2.2"
     },
     "scripts": {
-        "post-update-cmd": "bash vendor/pagarme/git-hooks/phpcs-pre-commit/install.sh",
         "test": [
             "@composer install",
             "vendor/bin/phpunit"


### PR DESCRIPTION
### Description
This package is used to validate de code style but, this validation is
done before commits and against PEAR standard. This isn't working well
in development environment and on travis-ci environments. So, this PR
intent to remove this package from project to avoid problems on
travis-ci and, enable the implementation to another tools to made
validate coding standards like codeclimante etc.

### Tests
No tests added but, all existent are "green"