### PR TITLE
Fix request timeout on "legacy" guzzle versions

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -81,10 +81,14 @@ class Client
     private function buildRequest($apiRequest)
     {
         if (class_exists('\\GuzzleHttp\\Message\\Request')) {
+            $options = array_merge(
+                $this->requestOptions,
+                ['json' => $this->buildBody($apiRequest)]
+            );
             return $this->client->createRequest(
                 $apiRequest->getMethod(),
                 $apiRequest->getPath(),
-                ['json' => $this->buildBody($apiRequest)]
+                $options
             );
         }
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -18,8 +18,14 @@ class Client
 
     /**
      * @var int
+     * @deprecated
      */
     private $timeout;
+
+    /**
+     * @var array
+     */
+    private $requestOptions = [];
 
     /**
      * @param \GuzzleHttp\Client $client
@@ -29,11 +35,15 @@ class Client
     public function __construct(
         GuzzleClient $client,
         $apiKey,
-        $timeout = null
+        $timeout = null,
+        $requestOptions = []
     ) {
         $this->client  = $client;
         $this->apiKey  = $apiKey;
-        $this->timeout = $timeout;
+        $this->requestOptions = array_merge(
+            ['timeout' => $timeout],
+            $requestOptions
+        );
     }
 
     /**
@@ -48,7 +58,7 @@ class Client
         try {
             $response = $this->client->send(
                 $request,
-                ['timeout' => $this->timeout]
+                $this->requestOptions
             );
 
             return json_decode($response->getBody()->getContents());

--- a/lib/PagarMe.php
+++ b/lib/PagarMe.php
@@ -128,11 +128,13 @@ class PagarMe
     /**
      * @param string $apiKey
      * @param int|null $timeout
+     * @param array $requestOptions
      */
     public function __construct(
         $apiKey,
         $timeout = null,
-        $headers = []
+        $headers = [],
+        $requestOptions = []
     ) {
         $this->client = new Client(
             new GuzzleClient(
@@ -145,7 +147,8 @@ class PagarMe
                 ]
             ),
             $apiKey,
-            $timeout
+            $timeout,
+            $requestOptions
         );
     }
 

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -69,7 +69,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                         'json' => [
                             'content'        => self::CONTENT,
                             'api_key'        => self::API_KEY
-                        ]
+                        ],
+                        'timeout' => null
                     ]
                 )
                 ->willReturn($this->getMock('GuzzleHttp\Message\RequestInterface'));


### PR DESCRIPTION
### Description

Theres a big difference between `5.*` and `6.*` guzzle majors. So, in the `PagarMe\Sdk\Client::buildRequest` method the sdk should instantiate the correct requests objects accordingly its contracts, in this case twice: `\GuzzleHttp\Message\Request` and `\GuzzleHttp\Psr7\Request`.

If the user define request options, and use guzzle `5.*` this options should be within the request object. If the major is `6.*` the options should be informed on `\GuzzleHttp\Client::send()` method as a second argument.

This fixes the described behavior above creating a new `PagarMe\Sdk\Client::$requestOptions` property and informing it on the right places.

### Tests
No new tests was created but, the new options is validated on existent tests