### PR TITLE
Add agencia DV to bank account payload

### DIFF
--- a/lib/Recipient/Request/RecipientCreate.php
+++ b/lib/Recipient/Request/RecipientCreate.php
@@ -110,6 +110,7 @@ class RecipientCreate implements RequestInterface
             'bank_account' =>[
                 'bank_code'       => $bankAccount->getBankCode(),
                 'agencia'         => $bankAccount->getAgencia(),
+                'agencia_dv'      => $bankAccount->getAgenciaDv(),
                 'conta'           => $bankAccount->getConta(),
                 'conta_dv'        => $bankAccount->getContaDv(),
                 'document_number' => $bankAccount->getDocumentNumber(),

--- a/lib/Recipient/Request/RecipientUpdate.php
+++ b/lib/Recipient/Request/RecipientUpdate.php
@@ -38,6 +38,7 @@ class RecipientUpdate implements RequestInterface
             'bank_account' =>[
                 'bank_code'       => $bankAccount->getBankCode(),
                 'agencia'         => $bankAccount->getAgencia(),
+                'agencia_dv'      => $bankAccount->getAgenciaDv(),
                 'conta'           => $bankAccount->getConta(),
                 'conta_dv'        => $bankAccount->getContaDv(),
                 'document_number' => $bankAccount->getDocumentNumber(),

--- a/tests/unit/Recipient/Request/RecipientCreateTest.php
+++ b/tests/unit/Recipient/Request/RecipientCreateTest.php
@@ -13,6 +13,7 @@ class RecipientCreateTest extends \PHPUnit_Framework_TestCase
 
     const BANK_CODE       = 237;
     const AGENCIA         = 1383;
+    const AGENCIA_DV      = 5;
     const CONTA           = 13399;
     const CONTA_DV        = 2;
     const DOCUMENT_NUMBER = 15344812140;
@@ -161,6 +162,7 @@ class RecipientCreateTest extends \PHPUnit_Framework_TestCase
 
         $bankAccountMock->method('getBankCode')->willReturn(self::BANK_CODE);
         $bankAccountMock->method('getAgencia')->willReturn(self::AGENCIA);
+        $bankAccountMock->method('getAgenciaDv')->willReturn(self::AGENCIA_DV);
         $bankAccountMock->method('getConta')->willReturn(self::CONTA);
         $bankAccountMock->method('getContaDv')->willReturn(self::CONTA_DV);
         $bankAccountMock->method('getDocumentNumber')->willReturn(self::DOCUMENT_NUMBER);
@@ -183,6 +185,7 @@ class RecipientCreateTest extends \PHPUnit_Framework_TestCase
             [
                 'bank_code'       => self::BANK_CODE,
                 'agencia'         => self::AGENCIA,
+                'agencia_dv'      => self::AGENCIA_DV,
                 'conta'           => self::CONTA,
                 'conta_dv'        => self::CONTA_DV,
                 'document_number' => self::DOCUMENT_NUMBER,

--- a/tests/unit/Recipient/Request/RecipientCreateTest.php
+++ b/tests/unit/Recipient/Request/RecipientCreateTest.php
@@ -194,4 +194,47 @@ class RecipientCreateTest extends \PHPUnit_Framework_TestCase
             $payload['bank_account']
         );
     }
+
+    /**
+     * @test
+     */
+    public function mustNotContainAgenciaDv()
+    {
+        $bankAccountMock = $this->getMockBuilder('PagarMe\Sdk\BankAccount\BankAccount')
+          ->disableOriginalConstructor()
+          ->getMock();
+
+        $bankAccountMock->method('getBankCode')->willReturn(self::BANK_CODE);
+        $bankAccountMock->method('getAgencia')->willReturn(self::AGENCIA);
+        $bankAccountMock->method('getAgenciaDv')->willReturn(null);
+        $bankAccountMock->method('getConta')->willReturn(self::CONTA);
+        $bankAccountMock->method('getContaDv')->willReturn(self::CONTA_DV);
+        $bankAccountMock->method('getDocumentNumber')->willReturn(self::DOCUMENT_NUMBER);
+        $bankAccountMock->method('getLegalName')->willReturn(self::LEGAL_NAME);
+
+        $recipientCreate = new RecipientCreate(
+            $bankAccountMock,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+
+        $payload = $recipientCreate->getPayload();
+
+        $this->assertContains('bank_account', array_keys($payload));
+        $this->assertEquals(
+            [
+                'bank_code'       => self::BANK_CODE,
+                'agencia'         => self::AGENCIA,
+                'agencia_dv'      => null,
+                'conta'           => self::CONTA,
+                'conta_dv'        => self::CONTA_DV,
+                'document_number' => self::DOCUMENT_NUMBER,
+                'legal_name'      => self::LEGAL_NAME,
+            ],
+            $payload['bank_account']
+        );
+    }
 }

--- a/tests/unit/Recipient/Request/RecipientUpdateTest.php
+++ b/tests/unit/Recipient/Request/RecipientUpdateTest.php
@@ -20,6 +20,7 @@ class RecipientUpdateTest extends \PHPUnit_Framework_TestCase
 
     const BANK_CODE       = 237;
     const AGENCIA         = 1383;
+    const AGENCIA_DV      = 5;
     const CONTA           = 13399;
     const CONTA_DV        = 2;
     const DOCUMENT_NUMBER = 15344812140;
@@ -67,6 +68,7 @@ class RecipientUpdateTest extends \PHPUnit_Framework_TestCase
         $bankAccountMock->method('getId')->willReturn(self::BANK_ACCOUNT_ID);
         $bankAccountMock->method('getBankCode')->willReturn(self::BANK_CODE);
         $bankAccountMock->method('getAgencia')->willReturn(self::AGENCIA);
+        $bankAccountMock->method('getAgenciaDv')->willReturn(self::AGENCIA_DV);
         $bankAccountMock->method('getConta')->willReturn(self::CONTA);
         $bankAccountMock->method('getContaDv')->willReturn(self::CONTA_DV);
         $bankAccountMock->method('getDocumentNumber')->willReturn(self::DOCUMENT_NUMBER);
@@ -101,6 +103,7 @@ class RecipientUpdateTest extends \PHPUnit_Framework_TestCase
                 'bank_account' => [
                     'bank_code'       => self::BANK_CODE,
                     'agencia'         => self::AGENCIA,
+                    'agencia_dv'      => self::AGENCIA_DV,
                     'conta'           => self::CONTA,
                     'conta_dv'        => self::CONTA_DV,
                     'document_number' => self::DOCUMENT_NUMBER,

--- a/tests/unit/Recipient/Request/RecipientUpdateTest.php
+++ b/tests/unit/Recipient/Request/RecipientUpdateTest.php
@@ -113,4 +113,62 @@ class RecipientUpdateTest extends \PHPUnit_Framework_TestCase
             $recipientUpdate->getPayload()
         );
     }
+
+    /**
+     * @test
+     */
+    public function mustNotContainAgenciaDv()
+    {
+        $bankAccountMock = $this->getMockBuilder('PagarMe\Sdk\BankAccount\BankAccount')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $bankAccountMock->method('getId')->willReturn(self::BANK_ACCOUNT_ID);
+        $bankAccountMock->method('getBankCode')->willReturn(self::BANK_CODE);
+        $bankAccountMock->method('getAgencia')->willReturn(self::AGENCIA);
+        $bankAccountMock->method('getAgenciaDv')->willReturn(null);
+        $bankAccountMock->method('getConta')->willReturn(self::CONTA);
+        $bankAccountMock->method('getContaDv')->willReturn(self::CONTA_DV);
+        $bankAccountMock->method('getDocumentNumber')->willReturn(self::DOCUMENT_NUMBER);
+        $bankAccountMock->method('getLegalName')->willReturn(self::LEGAL_NAME);
+
+        $recipientMock = $this->getMockBuilder('PagarMe\Sdk\Recipient\Recipient')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $recipientMock->method('getBankAccount')->willReturn($bankAccountMock);
+        $recipientMock->method('getTransferInterval')
+            ->willReturn(self::TRANSFER_INTERVAL);
+        $recipientMock->method('getTransferDay')
+            ->willReturn(self::TRANSFER_DAY);
+        $recipientMock->method('getTransferEnabled')
+            ->willReturn(self::TRANSFER_ENABLED);
+        $recipientMock->method('getAutomaticAnticipationEnabled')
+            ->willReturn(self::AUTOMATIC_ANTICIPATION_ENABLED);
+        $recipientMock->method('getAnticipatableVolumePercentage')
+            ->willReturn(self::ANTICIPATABLE_VOLUME_PERCENTAGE);
+
+        $recipientUpdate = new RecipientUpdate($recipientMock);
+
+        $this->assertEquals(
+            [
+                'transfer_interval'               => self::TRANSFER_INTERVAL,
+                'transfer_day'                    => self::TRANSFER_DAY,
+                'transfer_enabled'                => self::TRANSFER_ENABLED,
+                'automatic_anticipation_enabled'  => self::AUTOMATIC_ANTICIPATION_ENABLED,
+                'anticipatable_volume_percentage' => self::ANTICIPATABLE_VOLUME_PERCENTAGE,
+                'bank_account_id'                 => self::BANK_ACCOUNT_ID,
+                'bank_account' => [
+                    'bank_code'       => self::BANK_CODE,
+                    'agencia'         => self::AGENCIA,
+                    'agencia_dv'      => null,
+                    'conta'           => self::CONTA,
+                    'conta_dv'        => self::CONTA_DV,
+                    'document_number' => self::DOCUMENT_NUMBER,
+                    'legal_name'      => self::LEGAL_NAME
+                ]
+            ],
+            $recipientUpdate->getPayload()
+        );
+    }
 }


### PR DESCRIPTION
### Description
When creating a bank account instance like this:

```php
$bankAccount = new \PagarMe\Sdk\BankAccount\BankAccount([
    "bank_code" => "55",
    "agencia" => "1111",
    "agencia_dv" => "9",
    "conta" => "54283",
    "type" => "conta_corrente",
    "conta_dv" => "3",
    "document_number" => "10833324063",
    "legal_name" => "Saitama"
]);
```
No request is made to Pagar.me API (does not generate an id) thus causing the `agencia_dv` property to use its default `NULL` value when used in a Recipient creation/update request. This PR adds the parameter in order to solve this problem.

### Tests
- Unit
- Coverage
- Integration
