### PR TITLE
Create pending_review status

### DIFF
--- a/lib/Transaction/AbstractTransaction.php
+++ b/lib/Transaction/AbstractTransaction.php
@@ -16,6 +16,7 @@ abstract class AbstractTransaction
     const WAITING_PAYMENT = 'waiting_payment';
     const PENDING_REFUND  = 'pending_refund';
     const REFUSED         = 'refused';
+    const PENDING_REVIEW  = 'pending_review';
 
     /**
      * @var int
@@ -481,6 +482,14 @@ abstract class AbstractTransaction
     public function isRefused()
     {
         return $this->status == self::REFUSED;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isPendingReview()
+    {
+        return $this->status == self::PENDING_REVIEW;
     }
 
     /**


### PR DESCRIPTION
### Description

There's a new status `pending_review` on Pagar.me's API. This PR aims to
create a new const and a method `isPendingReview` on `AbstractTransaction` public interface.

This will be helpfull and applies [_Tell, don't ask_](https://martinfowler.com/bliki/TellDontAsk.html) principle and avoid something like this:

```php
$transaction = // transaction creation call

if ($transaction->getStatus() == 'pending_review') {
    // do something
}
```

With this new const/method will be:

```php
$transaction = // transaction creation call

if ($transaction->isPendingReview()) {
    // do something
}
```

### Issue

No related issue

### Tests

No new tests created.