### PR TITLE
transactions: add missing endpoints

### DIFF
--- a/src/Endpoints/Transactions.php
+++ b/src/Endpoints/Transactions.php
@@ -136,4 +136,18 @@ class Transactions extends Endpoint
             ['json' => $payload]
         );
     }
+
+    /**
+     * @param array $payload
+     *
+     * @return \ArrayObject
+     */
+    public function events(array $payload)
+    {
+        return $this->client->request(
+            self::GET,
+            Routes::transactions()->events($payload['id']),
+            ['json' => $payload]
+        );
+    }
 }

--- a/src/Endpoints/Transactions.php
+++ b/src/Endpoints/Transactions.php
@@ -108,4 +108,18 @@ class Transactions extends Endpoint
             ['json' => $payload]
         );
     }
+
+    /**
+     * @param array $payload
+     *
+     * @return \ArrayObject
+     */
+    public function listOperations(array $payload)
+    {
+        return $this->client->request(
+            self::GET,
+            Routes::transactions()->operations($payload['id']),
+            ['json' => $payload]
+        );
+    }
 }

--- a/src/Endpoints/Transactions.php
+++ b/src/Endpoints/Transactions.php
@@ -164,4 +164,18 @@ class Transactions extends Endpoint
             ['json' => $payload]
         );
     }
+
+    /**
+     * @param array $payload
+     *
+     * @return \ArrayObject
+     */
+    public function calculateInstallments(array $payload)
+    {
+        return $this->client->request(
+            self::GET,
+            Routes::transactions()->calculateInstallments(),
+            ['json' => $payload]
+        );
+    }
 }

--- a/src/Endpoints/Transactions.php
+++ b/src/Endpoints/Transactions.php
@@ -122,4 +122,18 @@ class Transactions extends Endpoint
             ['json' => $payload]
         );
     }
+
+    /**
+     * @param array $payload
+     *
+     * @return \ArrayObject
+     */
+    public function collectPayment(array $payload)
+    {
+        return $this->client->request(
+            self::POST,
+            Routes::transactions()->collectPayment($payload['id']),
+            ['json' => $payload]
+        );
+    }
 }

--- a/src/Endpoints/Transactions.php
+++ b/src/Endpoints/Transactions.php
@@ -150,4 +150,18 @@ class Transactions extends Endpoint
             ['json' => $payload]
         );
     }
+
+    /**
+     * @param array $payload
+     *
+     * @return \ArrayObject
+     */
+    public function simulateStatus(array $payload)
+    {
+        return $this->client->request(
+            self::PUT,
+            Routes::transactions()->details($payload['id']),
+            ['json' => $payload]
+        );
+    }
 }

--- a/src/Endpoints/Transactions.php
+++ b/src/Endpoints/Transactions.php
@@ -77,4 +77,35 @@ class Transactions extends Endpoint
             ['json' => $payload]
         );
     }
+
+    /**
+     * @param array $payload
+     *
+     * @return \ArrayObject
+     */
+    public function listPayables(array $payload)
+    {
+        return $this->client->request(
+            self::GET,
+            Routes::transactions()->payables($payload['id']),
+            ['json' => $payload]
+        );
+    }
+
+    /**
+     * @param array $payload
+     *
+     * @return \ArrayObject
+     */
+    public function getPayable(array $payload)
+    {
+        return $this->client->request(
+            self::GET,
+            Routes::transactions()->payablesDetails(
+                $payload['transaction_id'],
+                $payload['payable_id']
+            ),
+            ['json' => $payload]
+        );
+    }
 }

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -37,6 +37,10 @@ class Routes
             return "transactions/$transactionId/payables/$payableId";
         };
 
+        $anonymous->operations = static function ($id) {
+            return "transactions/$id/operations";
+        };
+
         return $anonymous;
     }
 

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -41,6 +41,10 @@ class Routes
             return "transactions/$id/operations";
         };
 
+        $anonymous->collectPayment = static function ($id) {
+            return "transactions/$id/collect_payment";
+        };
+
         return $anonymous;
     }
 

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -29,6 +29,14 @@ class Routes
             return "transactions/$id/refund";
         };
 
+        $anonymous->payables = static function ($id) {
+            return "transactions/$id/payables";
+        };
+
+        $anonymous->payablesDetails = static function ($transactionId, $payableId) {
+            return "transactions/$transactionId/payables/$payableId";
+        };
+
         return $anonymous;
     }
 

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -49,6 +49,10 @@ class Routes
             return "transactions/$id/events";
         };
 
+        $anonymous->calculateInstallments = static function () {
+            return "transactions/calculate_installments_amount";
+        };
+
         return $anonymous;
     }
 

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -45,6 +45,10 @@ class Routes
             return "transactions/$id/collect_payment";
         };
 
+        $anonymous->events = static function ($id) {
+            return "transactions/$id/events";
+        };
+
         return $anonymous;
     }
 

--- a/tests/unit/Endpoints/PagarMeTestCase.php
+++ b/tests/unit/Endpoints/PagarMeTestCase.php
@@ -51,6 +51,19 @@ abstract class PagarMeTestCase extends TestCase
 
     /**
      * @param array $container
+     *
+     * @return string
+     */
+    protected static function getBody($container)
+    {
+        $requestBody = $container['request']->getBody();
+        $bodySize = $requestBody->getSize();
+
+        return $requestBody->read($bodySize);
+    }
+
+    /**
+     * @param array $container
      * @param GuzzleHttp\Handler\MockHandler $mock
      *
      * @return PagarMe\Client

--- a/tests/unit/Endpoints/TransactionsTest.php
+++ b/tests/unit/Endpoints/TransactionsTest.php
@@ -18,6 +18,12 @@ final class TransactionTest extends PagarMeTestCase
             'list' => new MockHandler([
                 new Response(200, [], self::jsonMock('TransactionListMock')),
                 new Response(200, [], '[]')
+            ]),
+            'payableList' => new MockHandler([
+                new Response(200, [], self::jsonMock('PayableListMock'))
+            ]),
+            'payable' => new MockHandler([
+                new Response(200, [], self::jsonMock('PayableMock'))
             ])
         ]]];
     }
@@ -209,6 +215,59 @@ final class TransactionTest extends PagarMeTestCase
         );
         $this->assertEquals(
             json_decode(self::jsonMock('TransactionMock'), true),
+            $response->getArrayCopy()
+        );
+    }
+
+    /**
+     * @dataProvider transactionProvider
+     */
+    public function testTransactionPayablesList($mock)
+    {
+        $requestsContainer = [];
+        $client = self::buildClient($requestsContainer, $mock['payableList']);
+
+        $response = $client->transactions()->listPayables([
+            'id' => 1,
+        ]);
+
+        $this->assertEquals(
+            '/1/transactions/1/payables',
+            self::getRequestUri($requestsContainer[0])
+        );
+        $this->assertEquals(
+            Transactions::GET,
+            self::getRequestMethod($requestsContainer[0])
+        );
+        $this->assertEquals(
+            json_decode(self::jsonMock('PayableListMock'), true),
+            $response->getArrayCopy()
+        );
+    }
+
+    /**
+     * @dataProvider transactionProvider
+     */
+    public function testTransactionGetPayable($mock)
+    {
+        $requestsContainer = [];
+        $client = self::buildClient($requestsContainer, $mock['payable']);
+
+        $response = $client->transactions()->getPayable([
+            'transaction_id' => 12345678,
+            'payable_id' => 87654321
+        ]);
+
+        $this->assertEquals(
+            '/1/transactions/12345678/payables/87654321',
+            self::getRequestUri($requestsContainer[0])
+        );
+        $this->assertEquals(
+            Transactions::GET,
+            self::getRequestMethod($requestsContainer[0])
+        );
+        $this->assertEquals(
+            json_decode(self::jsonMock('PayableMock'), true),
             $response->getArrayCopy()
         );
     }

--- a/tests/unit/Endpoints/TransactionsTest.php
+++ b/tests/unit/Endpoints/TransactionsTest.php
@@ -300,4 +300,38 @@ final class TransactionTest extends PagarMeTestCase
             $response->getArrayCopy()
         );
     }
+
+    /**
+     * @dataProvider transactionProvider
+     */
+    public function testTransactionCollectPayment($mock)
+    {
+        $requestsContainer = [];
+        $client = self::buildClient($requestsContainer, $mock['transaction']);
+
+        $response = $client->transactions()->collectPayment([
+            'id' => 12345678,
+            'email' => 'teste@email.com'
+        ]);
+
+        $this->assertEquals(
+            Transactions::POST,
+            self::getRequestMethod($requestsContainer[0])
+        );
+
+        $this->assertEquals(
+            '/1/transactions/12345678/collect_payment',
+            self::getRequestUri($requestsContainer[0])
+        );
+
+        $this->assertContains(
+            '"email":"teste@email.com"',
+            self::getBody($requestsContainer[0])
+        );
+
+        $this->assertEquals(
+            json_decode(self::jsonMock('TransactionMock'), true),
+            $response->getArrayCopy()
+        );
+    }
 }

--- a/tests/unit/Endpoints/TransactionsTest.php
+++ b/tests/unit/Endpoints/TransactionsTest.php
@@ -30,6 +30,9 @@ final class TransactionTest extends PagarMeTestCase
             ]),
             'events' => new MockHandler([
                 new Response(200, [], self::jsonMock('EventListMock'))
+            ]),
+            'calculateInstallments' => new MockHandler([
+                new Response(200, [], self::jsonMock('CalculateInstallmentsMock'))
             ])
         ]]];
     }
@@ -391,6 +394,53 @@ final class TransactionTest extends PagarMeTestCase
         );
         $this->assertEquals(
             json_decode(self::jsonMock('TransactionMock'), true),
+            $response->getArrayCopy()
+        );
+    }
+
+    /**
+     * @dataProvider transactionProvider
+     */
+    public function testTransactionCalculateInstallments($mock)
+    {
+        $requestsContainer = [];
+        $client = self::buildClient($requestsContainer, $mock['calculateInstallments']);
+
+        $response = $client->transactions()->calculateInstallments([
+            'amount' => 10000,
+            'free_installments' => 1,
+            'max_installments' => 12,
+            'interest_rate' => 13
+        ]);
+
+        $requestBody = self::getBody($requestsContainer[0]);
+
+        $this->assertEquals(
+            '/1/transactions/calculate_installments_amount',
+            self::getRequestUri($requestsContainer[0])
+        );
+        $this->assertContains(
+            '"amount":10000',
+            $requestBody
+        );
+        $this->assertContains(
+            '"free_installments":1',
+            $requestBody
+        );
+        $this->assertContains(
+            '"max_installments":12',
+            $requestBody
+        );
+        $this->assertContains(
+            '"interest_rate":13',
+            $requestBody
+        );
+        $this->assertEquals(
+            Transactions::GET,
+            self::getRequestMethod($requestsContainer[0])
+        );
+        $this->assertEquals(
+            json_decode(self::jsonMock('CalculateInstallmentsMock'), true),
             $response->getArrayCopy()
         );
     }

--- a/tests/unit/Endpoints/TransactionsTest.php
+++ b/tests/unit/Endpoints/TransactionsTest.php
@@ -27,6 +27,9 @@ final class TransactionTest extends PagarMeTestCase
             ]),
             'operations' => new MockHandler([
                 new Response(200, [], self::jsonMock('OperationListMock'))
+            ]),
+            'events' => new MockHandler([
+                new Response(200, [], self::jsonMock('EventListMock'))
             ])
         ]]];
     }
@@ -331,6 +334,32 @@ final class TransactionTest extends PagarMeTestCase
 
         $this->assertEquals(
             json_decode(self::jsonMock('TransactionMock'), true),
+            $response->getArrayCopy()
+        );
+    }
+
+    /**
+     * @dataProvider transactionProvider
+     */
+    public function testTransactionEvents($mock)
+    {
+        $requestsContainer = [];
+        $client = self::buildClient($requestsContainer, $mock['events']);
+
+        $response = $client->transactions()->events([
+            'id' => 12345678,
+        ]);
+
+        $this->assertEquals(
+            '/1/transactions/12345678/events',
+            self::getRequestUri($requestsContainer[0])
+        );
+        $this->assertEquals(
+            Transactions::GET,
+            self::getRequestMethod($requestsContainer[0])
+        );
+        $this->assertEquals(
+            json_decode(self::jsonMock('EventListMock'), true),
             $response->getArrayCopy()
         );
     }

--- a/tests/unit/Endpoints/TransactionsTest.php
+++ b/tests/unit/Endpoints/TransactionsTest.php
@@ -24,6 +24,9 @@ final class TransactionTest extends PagarMeTestCase
             ]),
             'payable' => new MockHandler([
                 new Response(200, [], self::jsonMock('PayableMock'))
+            ]),
+            'operations' => new MockHandler([
+                new Response(200, [], self::jsonMock('OperationListMock'))
             ])
         ]]];
     }
@@ -268,6 +271,32 @@ final class TransactionTest extends PagarMeTestCase
         );
         $this->assertEquals(
             json_decode(self::jsonMock('PayableMock'), true),
+            $response->getArrayCopy()
+        );
+    }
+
+    /**
+     * @dataProvider transactionProvider
+     */
+    public function testTransactionOperationsList($mock)
+    {
+        $requestsContainer = [];
+        $client = self::buildClient($requestsContainer, $mock['operations']);
+
+        $response = $client->transactions()->listOperations([
+            'id' => 12345678,
+        ]);
+
+        $this->assertEquals(
+            '/1/transactions/12345678/operations',
+            self::getRequestUri($requestsContainer[0])
+        );
+        $this->assertEquals(
+            Transactions::GET,
+            self::getRequestMethod($requestsContainer[0])
+        );
+        $this->assertEquals(
+            json_decode(self::jsonMock('OperationListMock'), true),
             $response->getArrayCopy()
         );
     }

--- a/tests/unit/Endpoints/TransactionsTest.php
+++ b/tests/unit/Endpoints/TransactionsTest.php
@@ -363,4 +363,35 @@ final class TransactionTest extends PagarMeTestCase
             $response->getArrayCopy()
         );
     }
+
+    /**
+     * @dataProvider transactionProvider
+     */
+    public function testTransactionSimulateStatus($mock)
+    {
+        $requestsContainer = [];
+        $client = self::buildClient($requestsContainer, $mock['transaction']);
+
+        $response = $client->transactions()->simulateStatus([
+            'id' => 12345678,
+            'status' => 'paid'
+        ]);
+
+        $this->assertEquals(
+            '/1/transactions/12345678',
+            self::getRequestUri($requestsContainer[0])
+        );
+        $this->assertContains(
+            '"status":"paid"',
+            self::getBody($requestsContainer[0])
+        );
+        $this->assertEquals(
+            Transactions::PUT,
+            self::getRequestMethod($requestsContainer[0])
+        );
+        $this->assertEquals(
+            json_decode(self::jsonMock('TransactionMock'), true),
+            $response->getArrayCopy()
+        );
+    }
 }

--- a/tests/unit/Mocks/CalculateInstallmentsMock.json
+++ b/tests/unit/Mocks/CalculateInstallmentsMock.json
@@ -1,0 +1,19 @@
+{
+  "installments": {
+    "1": {
+      "installment": 1,
+      "amount": 10000,
+      "installment_amount": 10000
+    },
+    "2": {
+      "installment": 2,
+      "amount": 10598,
+      "installment_amount": 5299
+    },
+    "3": {
+      "installment": 3,
+      "amount": 10897,
+      "installment_amount": 3632
+    }
+  }
+}

--- a/tests/unit/Mocks/EventListMock.json
+++ b/tests/unit/Mocks/EventListMock.json
@@ -1,0 +1,34 @@
+[
+  {
+    "object": "event",
+    "id": "ev_cj425qedh01us316d9fl09djb",
+    "name": "transaction_status_changed",
+    "model": "transaction",
+    "model_id": "1627864",
+    "payload": {
+      "old_status": "paid",
+      "desired_status": "refunded",
+      "current_status": "refunded"
+
+    },
+    "date_created": "2017-06-18T03:33:29.285Z",
+    "date_updated": "2017-06-18T03:33:29.285Z"
+
+  },
+  {
+    "object": "event",
+    "id": "ev_cj423rjq901o4cd6epsphao29",
+    "name": "transaction_status_changed",
+    "model": "transaction",
+    "model_id": "1627864",
+    "payload": {
+      "old_status": "processing",
+      "desired_status": "paid",
+      "current_status": "paid"
+
+    },
+    "date_created": "2017-06-18T02:38:23.649Z",
+    "date_updated": "2017-06-18T02:38:23.649Z"
+
+  }
+]

--- a/tests/unit/Mocks/OperationListMock.json
+++ b/tests/unit/Mocks/OperationListMock.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "go_cj423rfvs1co0023tb95ip38i",
+    "date_created": "2017-06-18T02:38:18.664Z",
+    "date_updated": "2017-06-18T02:38:18.909Z",
+    "status": "success",
+    "fail_reason": null,
+    "type": "capture",
+    "rollbacked": false,
+    "model": "transaction",
+    "model_id": "1627864",
+    "group_id": "gog_cj423rfvs1co1023tgmuch6f0",
+    "next_group_id": null,
+    "request_id": "gr_cj423rfvc1cnz023tjleg2wp6",
+    "started_at": 1497753498775,
+    "ended_at": 1497753498909,
+    "processor": "pagarme",
+    "processor_response_code": null,
+    "metadata": {
+      "environment": {
+        "captured_amount": 75000
+      }
+    }
+  },
+  {
+    "id": "go_cj423rfvz1co2023tznwhz9lk",
+    "date_created": "2017-06-18T02:38:18.671Z",
+    "date_updated": "2017-06-18T02:38:18.768Z",
+    "status": "success",
+    "fail_reason": null,
+    "type": "authorize",
+    "rollbacked": false,
+    "model": "transaction",
+    "model_id": "1627864",
+    "group_id": "gog_cj423rfvz1co3023tep5sw66m",
+    "next_group_id": "gog_cj423rfvs1co1023tgmuch6f0",
+    "request_id": "gr_cj423rfvc1cnz023tjleg2wp6",
+    "started_at": 1497753498691,
+    "ended_at": 1497753498768,
+    "processor": "pagarme",
+    "processor_response_code": "0000",
+    "metadata": {
+      "environment": {
+        "response_code": "0000",
+        "authorization_code": "713332",
+        "authorized_amount": 75000,
+        "tid": "1627864",
+        "nsu": "1627864"
+      }
+    }
+  }
+]

--- a/tests/unit/RoutesTest.php
+++ b/tests/unit/RoutesTest.php
@@ -39,6 +39,8 @@ class RoutesTest extends TestCase
         $this->assertiscallable($routes->payablesDetails);
         $this->assertobjecthasattribute('operations', $routes);
         $this->assertiscallable($routes->operations);
+        $this->assertobjecthasattribute('collectPayment', $routes);
+        $this->assertiscallable($routes->collectPayment);
     }
 
     public function testCustomerRoutes()

--- a/tests/unit/RoutesTest.php
+++ b/tests/unit/RoutesTest.php
@@ -43,6 +43,8 @@ class RoutesTest extends TestCase
         $this->assertiscallable($routes->collectPayment);
         $this->assertobjecthasattribute('events', $routes);
         $this->assertiscallable($routes->events);
+        $this->assertobjecthasattribute('calculateInstallments', $routes);
+        $this->assertiscallable($routes->calculateInstallments);
     }
 
     public function testCustomerRoutes()

--- a/tests/unit/RoutesTest.php
+++ b/tests/unit/RoutesTest.php
@@ -37,6 +37,8 @@ class RoutesTest extends TestCase
         $this->assertiscallable($routes->payables);
         $this->assertobjecthasattribute('payablesDetails', $routes);
         $this->assertiscallable($routes->payablesDetails);
+        $this->assertobjecthasattribute('operations', $routes);
+        $this->assertiscallable($routes->operations);
     }
 
     public function testCustomerRoutes()

--- a/tests/unit/RoutesTest.php
+++ b/tests/unit/RoutesTest.php
@@ -41,6 +41,8 @@ class RoutesTest extends TestCase
         $this->assertiscallable($routes->operations);
         $this->assertobjecthasattribute('collectPayment', $routes);
         $this->assertiscallable($routes->collectPayment);
+        $this->assertobjecthasattribute('events', $routes);
+        $this->assertiscallable($routes->events);
     }
 
     public function testCustomerRoutes()

--- a/tests/unit/RoutesTest.php
+++ b/tests/unit/RoutesTest.php
@@ -31,8 +31,12 @@ class RoutesTest extends TestCase
         $this->assertIsCallable($routes->details);
         $this->assertObjectHasAttribute('capture', $routes);
         $this->assertIsCallable($routes->capture);
-        $this->assertObjectHasAttribute('refund', $routes);
-        $this->assertIsCallable($routes->refund);
+        $this->assertobjecthasattribute('refund', $routes);
+        $this->assertiscallable($routes->refund);
+        $this->assertobjecthasattribute('payables', $routes);
+        $this->assertiscallable($routes->payables);
+        $this->assertobjecthasattribute('payablesDetails', $routes);
+        $this->assertiscallable($routes->payablesDetails);
     }
 
     public function testCustomerRoutes()


### PR DESCRIPTION
### Description

This PR add the transaction missing endpoints

- payables
- operations
- collect_payment
- events
- simulateStatus (PUT in `/transactions/:id`)
- calculate_installments_amount

### Issue number

No issue.

### Tests

Unit tests

For a better review, see the commits instead the full PR