### PR TITLE
Fix customer builder

### DIFF
--- a/lib/Customer/CustomerBuilder.php
+++ b/lib/Customer/CustomerBuilder.php
@@ -10,9 +10,11 @@ trait CustomerBuilder
      */
     private function buildCustomer($customerData)
     {
-        $customerData->address = new Address(
-            get_object_vars($customerData->addresses[0])
-        );
+        if (count($customerData->addresses) > 0) {
+            $customerData->address = new Address(
+                get_object_vars($customerData->addresses[0])
+            );
+        }
 
         $customerData->phone = new Phone($customerData->phones[0]);
 

--- a/lib/Customer/CustomerBuilder.php
+++ b/lib/Customer/CustomerBuilder.php
@@ -16,7 +16,9 @@ trait CustomerBuilder
             );
         }
 
-        $customerData->phone = new Phone($customerData->phones[0]);
+        if (count($customerData->phones) > 0) {
+            $customerData->phone = new Phone($customerData->phones[0]);
+        }
 
         $customerData->date_created = new \DateTime(
             $customerData->date_created

--- a/tests/unit/Customer/CustomerBuilderTest.php
+++ b/tests/unit/Customer/CustomerBuilderTest.php
@@ -50,4 +50,18 @@ class CustomerBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($customer);
     }
+
+    /**
+     * @test
+     */
+    public function mustCreateCustomerWithoutAddressCorrectly()
+    {
+        // @codingStandardsIgnoreLine
+        $payload = '{"object":"customer","document_number":"25123317171","document_type":"cpf","name":"John Doe","email":"john@test.com","born_at":null,"gender":null,"date_created":"2016-12-28T19:38:28.618Z","id":122444,"addresses":[],"phones":[{"object":"phone","ddi":"55","ddd":"11","number":"44445555","id":65844}]}';
+
+        $customer = $this->buildCustomer(json_decode($payload));
+
+        $this->assertInstanceOf('PagarMe\Sdk\Customer\Customer', $customer);
+        $this->assertInstanceOf('\DateTime', $customer->getDateCreated());
+    }
 }

--- a/tests/unit/Customer/CustomerBuilderTest.php
+++ b/tests/unit/Customer/CustomerBuilderTest.php
@@ -64,4 +64,18 @@ class CustomerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PagarMe\Sdk\Customer\Customer', $customer);
         $this->assertInstanceOf('\DateTime', $customer->getDateCreated());
     }
+
+    /**
+     * @test
+     */
+    public function mustCreateCustomerWithoutPhoneCorrectly()
+    {
+        // @codingStandardsIgnoreLine
+        $payload = '{"object":"customer","document_number":"25123317171","document_type":"cpf","name":"John Doe","email":"john@test.com","born_at":null,"gender":null,"date_created":"2016-12-28T19:38:28.618Z","id":122444,"addresses":[{"object":"address","street":"Rua Teste","complementary":null,"street_number":"123","neighborhood":"Centro","city":null,"state":null,"zipcode":"01034020","country":null,"id":68136}],"phones":[]}';
+
+        $customer = $this->buildCustomer(json_decode($payload));
+
+        $this->assertInstanceOf('PagarMe\Sdk\Customer\Customer', $customer);
+        $this->assertInstanceOf('\DateTime', $customer->getDateCreated());
+    }
 }


### PR DESCRIPTION
### Descrição

Não é possível capturar customers sem endereço ou telefone. 

### Número da Issue

#304 , #278 

### Testes Realizados

Utilizando api key de teste: 
1. Chamando  `customer()->get($id)`, 
2. Customer existe, porém a resposta vem sem endereço e telefone.
3. Erro retornado:

```
[2018-09-16 17:44:21] production.ERROR: Undefined offset: 0 {"exception":"[object] 
(ErrorException(code: 0): Undefined offset: 0 at ...vendor/pagarme/pagarme-
php/lib/Customer/CustomerBuilder.php:14)
````

