### PR TITLE
Altera retorno da API de ArrayObjects para array/stdClass

### DIFF
--- a/src/ResponseHandler.php
+++ b/src/ResponseHandler.php
@@ -15,12 +15,7 @@ class ResponseHandler
      */
     public static function success($payload)
     {
-        $json = self::toJson($payload);
-
-        return new \ArrayObject(
-            $json,
-            \ArrayObject::STD_PROP_LIST|\ArrayObject::ARRAY_AS_PROPS
-        );
+        return self::toJson($payload);
     }
 
     /**
@@ -49,15 +44,15 @@ class ResponseHandler
         }
 
         return new PagarMeException(
-            $jsonError['errors'][0]['type'],
-            $jsonError['errors'][0]['parameter_name'],
-            $jsonError['errors'][0]['message']
+            $jsonError->errors[0]->type,
+            $jsonError->errors[0]->parameter_name,
+            $jsonError->errors[0]->message
         );
     }
 
     private static function toJson($json)
     {
-        $jsonError = json_decode($json, true);
+        $jsonError = json_decode($json);
 
         if (json_last_error() != \JSON_ERROR_NONE) {
             throw new InvalidJsonException(json_last_error_msg());

--- a/tests/unit/Endpoints/BalanceOperations.php
+++ b/tests/unit/Endpoints/BalanceOperations.php
@@ -42,8 +42,8 @@ class BalanceOperationsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BalanceOperationsMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BalanceOperationsMock')),
+            $response
         );
     }
 
@@ -66,8 +66,8 @@ class BalanceOperationsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BalanceOperationsListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BalanceOperationsListMock')),
+            $response
         );
 
         $response = $client->balanceOperations()->getList([
@@ -87,8 +87,8 @@ class BalanceOperationsTest extends PagarMeTestCase
             $query
         );
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/BalancesTest.php
+++ b/tests/unit/Endpoints/BalancesTest.php
@@ -31,8 +31,8 @@ class BalancesTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BalanceMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BalanceMock')),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/BankAccountsTest.php
+++ b/tests/unit/Endpoints/BankAccountsTest.php
@@ -50,8 +50,8 @@ final class BankAccountTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BankAccountMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BankAccountMock')),
+            $response
         );
     }
 
@@ -75,8 +75,8 @@ final class BankAccountTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BankAccountListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BankAccountListMock')),
+            $response
         );
 
         $response = $client->bankAccounts()->getList([
@@ -91,8 +91,8 @@ final class BankAccountTest extends PagarMeTestCase
         $this->assertContains('bank_code=456', $query);
         $this->assertContains('agencia=7890', $query);
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -115,8 +115,8 @@ final class BankAccountTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BankAccountMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BankAccountMock')),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/BulkAnticipationsTest.php
+++ b/tests/unit/Endpoints/BulkAnticipationsTest.php
@@ -54,8 +54,8 @@ class BulkAnticipationsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BulkAnticipationMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BulkAnticipationMock')),
+            $response
         );
     }
 
@@ -82,8 +82,8 @@ class BulkAnticipationsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BulkAnticipationLimitsMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BulkAnticipationLimitsMock')),
+            $response
         );
     }
 
@@ -109,8 +109,8 @@ class BulkAnticipationsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BulkAnticipationMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BulkAnticipationMock')),
+            $response
         );
     }
 
@@ -136,8 +136,8 @@ class BulkAnticipationsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BulkAnticipationMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BulkAnticipationMock')),
+            $response
         );
     }
 
@@ -164,7 +164,7 @@ class BulkAnticipationsTest extends PagarMeTestCase
         );
         $this->assertEquals(
             [],
-            $response->getArrayCopy()
+            $response
         );
     }
 
@@ -189,8 +189,8 @@ class BulkAnticipationsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BulkAnticipationListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BulkAnticipationListMock')),
+            $response
         );
 
         $response = $client->bulkAnticipations()->getList([
@@ -206,8 +206,8 @@ class BulkAnticipationsTest extends PagarMeTestCase
         $this->assertContains('fee=4567', $query);
         $this->assertContains('anticipation_fee=8900', $query);
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/CardsTest.php
+++ b/tests/unit/Endpoints/CardsTest.php
@@ -49,8 +49,8 @@ class CardsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('CardMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('CardMock')),
+            $response
         );
     }
 
@@ -73,8 +73,8 @@ class CardsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('CardListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('CardListMock')),
+            $response
         );
 
         $response = $client->cards()->getList([
@@ -89,8 +89,8 @@ class CardsTest extends PagarMeTestCase
         $this->assertContains('holder_name=TESTE%20DE%20CARTAO', $query);
         $this->assertContains('first_digits=424242', $query);
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -115,8 +115,8 @@ class CardsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('CardMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('CardMock')),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/ChargebacksTest.php
+++ b/tests/unit/Endpoints/ChargebacksTest.php
@@ -41,8 +41,8 @@ final class ChargebacksTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('ChargebacksMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('ChargebacksMock')),
+            $response
         );
 
         $response = $client->chargebacks()->getList([
@@ -53,8 +53,8 @@ final class ChargebacksTest extends PagarMeTestCase
 
         $this->assertContains('transaction_id=12345', $query);
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/CustomersTest.php
+++ b/tests/unit/Endpoints/CustomersTest.php
@@ -59,8 +59,8 @@ final class CustomerTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('CustomerMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('CustomerMock')),
+            $response
         );
     }
 
@@ -83,8 +83,8 @@ final class CustomerTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('CustomerListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('CustomerListMock')),
+            $response
         );
 
         $response = $client->customers()->getList([
@@ -99,8 +99,8 @@ final class CustomerTest extends PagarMeTestCase
         $this->assertContains('email=fulano%40silva.com', $query);
         $this->assertContains('id=123456', $query);
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -123,8 +123,8 @@ final class CustomerTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('CustomerMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('CustomerMock')),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/PayablesTest.php
+++ b/tests/unit/Endpoints/PayablesTest.php
@@ -42,8 +42,8 @@ class PayablesTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PayableMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PayableMock')),
+            $response
         );
     }
 
@@ -66,8 +66,8 @@ class PayablesTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PayableListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PayableListMock')),
+            $response
         );
 
         $response = $client->payables()->getList([
@@ -88,8 +88,8 @@ class PayablesTest extends PagarMeTestCase
             $query
         );
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/PaymentLinksTest.php
+++ b/tests/unit/Endpoints/PaymentLinksTest.php
@@ -81,8 +81,8 @@ class PaymentLinksTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PaymentLinkMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PaymentLinkMock')),
+            $response
         );
     }
 
@@ -105,8 +105,8 @@ class PaymentLinksTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PaymentLinkListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PaymentLinkListMock')),
+            $response
         );
 
         $response = $client->paymentLinks()->getList([
@@ -118,8 +118,8 @@ class PaymentLinksTest extends PagarMeTestCase
             self::getQueryString($container[1])
         );
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -144,8 +144,8 @@ class PaymentLinksTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PaymentLinkMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PaymentLinkMock')),
+            $response
         );
     }
 
@@ -170,8 +170,8 @@ class PaymentLinksTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PaymentLinkMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PaymentLinkMock')),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/PlansTest.php
+++ b/tests/unit/Endpoints/PlansTest.php
@@ -46,8 +46,8 @@ final class PlanTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PlanMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PlanMock')),
+            $response
         );
     }
 
@@ -70,8 +70,8 @@ final class PlanTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PlanListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PlanListMock')),
+            $response
         );
 
         $response = $client->plans()->getList([
@@ -87,8 +87,8 @@ final class PlanTest extends PagarMeTestCase
         $this->assertContains('name=Super%20Duper%20Plan', $query);
 
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -111,8 +111,8 @@ final class PlanTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PlanMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PlanMock')),
+            $response
         );
     }
 
@@ -135,8 +135,8 @@ final class PlanTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PlanMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PlanMock')),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/PostbacksTest.php
+++ b/tests/unit/Endpoints/PostbacksTest.php
@@ -45,8 +45,8 @@ final class PostbacksTest extends PagarMeTestCase
             self::getRequestMethod($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PostbackMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PostbackMock')),
+            $response
         );
     }
 
@@ -72,8 +72,8 @@ final class PostbacksTest extends PagarMeTestCase
             self::getRequestMethod($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PostbackListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PostbackListMock')),
+            $response
         );
     }
 
@@ -100,8 +100,8 @@ final class PostbacksTest extends PagarMeTestCase
             self::getRequestMethod($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PostbackMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PostbackMock')),
+            $response
         );
     }
 

--- a/tests/unit/Endpoints/RecipientsTest.php
+++ b/tests/unit/Endpoints/RecipientsTest.php
@@ -59,8 +59,8 @@ final class RecipientTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('RecipientMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('RecipientMock')),
+            $response
         );
     }
 
@@ -83,8 +83,8 @@ final class RecipientTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('RecipientListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('RecipientListMock')),
+            $response
         );
 
         $response = $client->recipients()->getList([
@@ -100,8 +100,8 @@ final class RecipientTest extends PagarMeTestCase
         $this->assertContains('name=RECEBEDOR%20TESTE', $query);
 
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -124,8 +124,8 @@ final class RecipientTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('RecipientMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('RecipientMock')),
+            $response
         );
     }
 
@@ -156,8 +156,8 @@ final class RecipientTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('RecipientMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('RecipientMock')),
+            $response
         );
     }
 
@@ -182,8 +182,8 @@ final class RecipientTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BalanceMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BalanceMock')),
+            $response
         );
     }
 
@@ -208,8 +208,8 @@ final class RecipientTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BalanceOperationListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BalanceOperationListMock')),
+            $response
         );
 
         $response = $client->recipients()->listBalanceOperation([
@@ -224,8 +224,8 @@ final class RecipientTest extends PagarMeTestCase
         $this->assertContains('page=1', $query);
 
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -251,8 +251,8 @@ final class RecipientTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('BalanceOperationMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('BalanceOperationMock')),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/RefundsTest.php
+++ b/tests/unit/Endpoints/RefundsTest.php
@@ -41,8 +41,8 @@ final class RefundsTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('RefundsMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('RefundsMock')),
+            $response
         );
 
         $response = $client->refunds()->getList([
@@ -53,8 +53,8 @@ final class RefundsTest extends PagarMeTestCase
 
         $this->assertContains('transaction_id=12345', $query);
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/SubscriptionsTest.php
+++ b/tests/unit/Endpoints/SubscriptionsTest.php
@@ -75,8 +75,8 @@ class SubscriptionsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('SubscriptionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('SubscriptionMock')),
+            $response
         );
     }
 
@@ -99,8 +99,8 @@ class SubscriptionsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('SubscriptionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('SubscriptionMock')),
+            $response
         );
     }
 
@@ -123,8 +123,8 @@ class SubscriptionsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('SubscriptionListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('SubscriptionListMock')),
+            $response
         );
 
         $response = $client->subscriptions()->getList([
@@ -143,8 +143,8 @@ class SubscriptionsTest extends PagarMeTestCase
         $this->assertContains('payment_method=credit_card', $query);
 
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -171,8 +171,8 @@ class SubscriptionsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('SubscriptionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('SubscriptionMock')),
+            $response
         );
     }
 
@@ -197,8 +197,8 @@ class SubscriptionsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('SubscriptionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('SubscriptionMock')),
+            $response
         );
     }
 
@@ -223,8 +223,8 @@ class SubscriptionsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransactionListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransactionListMock')),
+            $response
         );
 
         $response = $client->subscriptions()->transactions([
@@ -241,8 +241,8 @@ class SubscriptionsTest extends PagarMeTestCase
         $this->assertContains('tid=162534', $query);
 
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -268,8 +268,8 @@ class SubscriptionsTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('SubscriptionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('SubscriptionMock')),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/TransactionsTest.php
+++ b/tests/unit/Endpoints/TransactionsTest.php
@@ -103,8 +103,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransactionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransactionMock')),
+            $response
         );
     }
 
@@ -128,8 +128,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransactionListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransactionListMock')),
+            $response
         );
 
         $response = $client->transactions()->getList([
@@ -145,8 +145,8 @@ final class TransactionTest extends PagarMeTestCase
         $this->assertContains('tid=2345678', $query);
 
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -169,8 +169,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestUri($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransactionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransactionMock')),
+            $response
         );
     }
 
@@ -196,8 +196,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransactionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransactionMock')),
+            $response
         );
     }
 
@@ -223,8 +223,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransactionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransactionMock')),
+            $response
         );
     }
 
@@ -249,8 +249,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PayableListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PayableListMock')),
+            $response
         );
     }
 
@@ -276,8 +276,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('PayableMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('PayableMock')),
+            $response
         );
     }
 
@@ -302,8 +302,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('OperationListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('OperationListMock')),
+            $response
         );
     }
 
@@ -336,8 +336,8 @@ final class TransactionTest extends PagarMeTestCase
         );
 
         $this->assertEquals(
-            json_decode(self::jsonMock('TransactionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransactionMock')),
+            $response
         );
     }
 
@@ -362,8 +362,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('EventListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('EventListMock')),
+            $response
         );
     }
 
@@ -393,8 +393,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransactionMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransactionMock')),
+            $response
         );
     }
 
@@ -440,8 +440,8 @@ final class TransactionTest extends PagarMeTestCase
             self::getRequestMethod($requestsContainer[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('CalculateInstallmentsMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('CalculateInstallmentsMock')),
+            $response
         );
     }
 }

--- a/tests/unit/Endpoints/TransfersTest.php
+++ b/tests/unit/Endpoints/TransfersTest.php
@@ -48,8 +48,8 @@ class TransfersTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransferMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransferMock')),
+            $response
         );
     }
 
@@ -72,8 +72,8 @@ class TransfersTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransferListMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransferListMock')),
+            $response
         );
 
         $response = $client->transfers()->getList([
@@ -92,8 +92,8 @@ class TransfersTest extends PagarMeTestCase
         );
 
         $this->assertEquals(
-            json_decode('[]', true),
-            $response->getArrayCopy()
+            json_decode('[]'),
+            $response
         );
     }
 
@@ -118,8 +118,8 @@ class TransfersTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransferMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransferMock')),
+            $response
         );
     }
 
@@ -144,8 +144,8 @@ class TransfersTest extends PagarMeTestCase
             self::getRequestUri($container[0])
         );
         $this->assertEquals(
-            json_decode(self::jsonMock('TransferMock'), true),
-            $response->getArrayCopy()
+            json_decode(self::jsonMock('TransferMock')),
+            $response
         );
     }
 }

--- a/tests/unit/ResponseHandlerTest.php
+++ b/tests/unit/ResponseHandlerTest.php
@@ -14,18 +14,26 @@ class ResponseHandlerTest extends TestCase
 
         $response = $handler->success('{"foo": "bar"}');
 
-        $this->assertInstanceOf(\ArrayObject::class, $response);
+        $this->assertInstanceOf(\stdClass::class, $response);
     }
 
     public function testReturnUsage()
     {
         $response = ResponseHandler::success('{"foo": "bar"}');
-    
+
         $this->assertObjectHasAttribute('foo', $response);
         $this->assertEquals('bar', $response->foo);
+    }
 
-        $this->assertArrayHasKey('foo', $response);
-        $this->assertEquals('bar', $response['foo']);
+    public function testReturnListOfObjects()
+    {
+        $response = ResponseHandler::success('[{"foo": "bar"},{"bar": "baz"}]');
+
+        $this->assertInternalType('array', $response, 'The list must be an array');
+        $this->assertObjectHasAttribute('foo', $response[0], 'The first index must be an object');
+        $this->assertEquals('bar', $response[0]->foo);
+        $this->assertObjectHasAttribute('bar', $response[1], 'The second index must be an object');
+        $this->assertEquals('baz', $response[1]->bar);
     }
 
     /**


### PR DESCRIPTION
### Descrição

Até então o retorno do SDK era feito através de_ArrayObjects_, o problema é que o subníveis eram _arrays_ e não _ArrayObject_ também. Para resolver este problema seria necessário implementar um _workaround_ para realizer a conversão recursivamente o que estaria suscetível a bugs e provavelmente, não performático.

Diante disso este PR altera o retorno de modo que utilize somente _arrays_ e objetos _stdClass_ diferenciando listas (array) do objetos em si cujas propriedades armazenarão as informações retornadas.

### Número da Issue

Não há

### Testes Realizados

Testes unitários.