### PR TITLE
Adiciona header User-Agent aos requests feitos pelo SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ require('vendor/autoload.php');
 $pagarme = new PagarMe\Client('SUA_CHAVE_DE_API');
 ```
 
+### Definindo headers customizados
+
+1. Se necessário for é possível definir headers http customizados para os requests. Para isso basta informá-los durante a instanciação do objeto `Client`:
+
+```php
+<?php
+require('vendor/autoload.php');
+
+$pagarme = new PagarMe\Client(
+    'SUA_CHAVE_DE_API',
+    ['headers' => ['MEU_HEADER_CUSTOMIZADO' => 'VALOR HEADER CUSTOMIZADO']]
+); 
+```
+
 E então, você pode poderá utilizar o cliente para fazer requisições ao Pagar.me, como nos exemplos abaixo.
 
 ## Transações

--- a/src/Client.php
+++ b/src/Client.php
@@ -41,6 +41,11 @@ class Client
     private $apiKey;
 
     /**
+     * @var string
+     */
+    private $userAgent;
+
+    /**
      * @var \PagarMe\Endpoints\Transactions
      */
     private $transactions;
@@ -134,6 +139,10 @@ class Client
             $options = array_merge($options, $extras);
         }
 
+        $this->userAgent = $this->buildUserAgent(
+            $extras['headers']['User-Agent']
+        );
+
         $this->http = new HttpClient($options);
 
         $this->transactions = new Transactions($this);
@@ -188,6 +197,30 @@ class Client
     public function getApiKey()
     {
         return $this->apiKey;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserAgent()
+    {
+        return $this->userAgent;
+    }
+
+    /**
+     * Build an user-agent string to be informed on requests
+     *
+     * @param string $customUserAgent
+     *
+     * @return string
+     */
+    private function buildUserAgent($customUserAgent = '')
+    {
+        return trim(sprintf(
+            '%s PHP/%s',
+            $customUserAgent,
+            phpversion()
+        ));
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -31,6 +31,11 @@ class Client
     const BASE_URI = 'https://api.pagar.me:443/1/';
 
     /**
+     * @var string header used to identify application's requests
+     */
+    const PAGARME_USER_AGENT_HEADER = 'X-PagarMe-User-Agent';
+
+    /**
      * @var \GuzzleHttp\Client
      */
     private $http;
@@ -234,7 +239,7 @@ class Client
     {
         return [
             'User-Agent' => $this->getUserAgent(),
-            'X-PagarMe-User-Agent' => $this->getUserAgent()
+            self::PAGARME_USER_AGENT_HEADER => $this->getUserAgent()
         ];
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -140,8 +140,10 @@ class Client
         }
 
         $this->userAgent = $this->buildUserAgent(
-            $extras['headers']['User-Agent']
+            $options['headers']['User-Agent']
         );
+
+        $options['headers'] = $this->addUserAgentHeaders();
 
         $this->http = new HttpClient($options);
 
@@ -221,6 +223,19 @@ class Client
             $customUserAgent,
             phpversion()
         ));
+    }
+
+    /**
+     * Append new keys (the default and pagarme) related to user-agent
+     *
+     * @return array
+     */
+    private function addUserAgentHeaders()
+    {
+        return [
+            'User-Agent' => $this->getUserAgent(),
+            'X-PagarMe-User-Agent' => $this->getUserAgent()
+        ];
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -144,9 +144,11 @@ class Client
             $options = array_merge($options, $extras);
         }
 
-        $this->userAgent = $this->buildUserAgent(
-            $options['headers']['User-Agent']
-        );
+        $userAgent = !is_null($options['headers']['User-Agent']) ?
+            $options['headers']['User-Agent'] :
+            '';
+
+        $this->userAgent = $this->buildUserAgent($userAgent);
 
         $options['headers'] = $this->addUserAgentHeaders();
 

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -108,6 +108,41 @@ final class ClientTest extends TestCase
         );
     }
 
+    public function testSuccessfulResponseWithCustomUserAgentHeader()
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $mock = new MockHandler([
+            new Response(200, [], '{"status":"Ok!"}'),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+
+        $client = new Client(
+            'apiKey',
+            [
+                'handler' => $handler,
+                'headers' => ['User-Agent' => 'MyCustomApplication/10.2.2']
+            ]
+        );
+
+        $response = $client->request(Endpoint::POST, 'transactions');
+
+        $this->assertEquals($response->status, "Ok!");
+        $this->assertEquals(
+            'api_key=apiKey',
+            $container[0]['request']->getUri()->getQuery()
+        );
+        $this->assertEquals(
+            'MyCustomApplication/10.2.2 PHP/5.6.37',
+            $container[0]['request']->getHeaderLine('User-Agent')
+        );
+        $this->assertEquals(
+            'MyCustomApplication/10.2.2 PHP/5.6.37',
+            $container[0]['request']->getHeaderLine('X-PagarMe-User-Agent')
+        );
+    }
+
     public function testTransactions()
     {
         $client = new Client('apiKey');

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -84,6 +84,30 @@ final class ClientTest extends TestCase
         $response = $client->request(Endpoint::POST, 'transactions');
     }
 
+    public function testDefaultUserAgent()
+    {
+        $client = new Client('apikey');
+
+        $this->assertEquals(
+            'PHP/5.6.37',
+            $client->getUserAgent(),
+            'The default user-agent must have php version'
+        );
+    }
+
+    public function testBuildUserAgentWithCustomHeader()
+    {
+        $client = new Client(
+            'apikey',
+            ['headers' => ['User-Agent' => 'MyCustomIntegration/3.14.0']]
+        );
+
+        $this->assertEquals(
+            'MyCustomIntegration/3.14.0 PHP/5.6.37',
+            $client->getUserAgent()
+        );
+    }
+
     public function testTransactions()
     {
         $client = new Client('apiKey');

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -88,8 +88,9 @@ final class ClientTest extends TestCase
     {
         $client = new Client('apikey');
 
+        $expectedUserAgent = sprintf('PHP/%s', phpversion());
         $this->assertEquals(
-            'PHP/5.6.37',
+            $expectedUserAgent,
             $client->getUserAgent(),
             'The default user-agent must have php version'
         );
@@ -101,9 +102,12 @@ final class ClientTest extends TestCase
             'apikey',
             ['headers' => ['User-Agent' => 'MyCustomIntegration/3.14.0']]
         );
-
+        $expectedUserAgent = sprintf(
+            'MyCustomIntegration/3.14.0 PHP/%s',
+            phpversion()
+        );
         $this->assertEquals(
-            'MyCustomIntegration/3.14.0 PHP/5.6.37',
+            $expectedUserAgent,
             $client->getUserAgent()
         );
     }
@@ -133,13 +137,20 @@ final class ClientTest extends TestCase
             'api_key=apiKey',
             $container[0]['request']->getUri()->getQuery()
         );
+
+        $expectedUserAgent = sprintf(
+            'MyCustomApplication/10.2.2 PHP/%s',
+            phpversion()
+        );
         $this->assertEquals(
-            'MyCustomApplication/10.2.2 PHP/5.6.37',
+            $expectedUserAgent,
             $container[0]['request']->getHeaderLine('User-Agent')
         );
         $this->assertEquals(
-            'MyCustomApplication/10.2.2 PHP/5.6.37',
-            $container[0]['request']->getHeaderLine('X-PagarMe-User-Agent')
+            $expectedUserAgent,
+            $container[0]['request']->getHeaderLine(
+                Client::PAGARME_USER_AGENT_HEADER
+            )
         );
     }
 


### PR DESCRIPTION
### Descrição

Com o intúito de mapear os requests feitos à api através do SDK, este PR adiciona aos headers de todos os requests realizados pelo SDK de PHP à API do Pagar.me. Por padrão o header é `User-Agent`, este é utilizado, mas o SDK envia também a mesma informação no header `X-PagarMe-User-Agent` que é um header customizado pela API.

### Número da Issue

Não há

### Testes Realizados

Testes unitários