### PR TITLE
Corrige instruções de instalação do SDK v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Você pode acessar a documentação oficial do Pagar.me acessando esse [link](ht
 
 Instale a biblioteca utilizando o comando
 
-`composer require pagarme/pagarme-php`
+`composer require pagarme/pagarme-php:v4.0.0-alpha`
 
 ## Configuração
 


### PR DESCRIPTION
### Descrição

As instruções de instalação do sdk não especifica a versão que deve ser instalada. Este PR ajusta esse problema.

### Número da Issue

Nenhuma issue

### Testes Realizados

Nenhum teste adicionado