### PR TITLE
response handler: fix client exception handler

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -21,6 +21,7 @@ use PagarMe\Endpoints\Payables;
 use PagarMe\Endpoints\BalanceOperations;
 use PagarMe\Endpoints\Chargebacks;
 use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\ClientException as ClientException;
 use PagarMe\Exceptions\InvalidJsonException;
 
 class Client
@@ -188,8 +189,10 @@ class Client
             return ResponseHandler::success($response->getBody());
         } catch (InvalidJsonException $exception) {
             throw $exception;
-        } catch (\Exception $exception) {
+        } catch (ClientException $exception) {
             ResponseHandler::failure($exception);
+        } catch (\Exception $exception) {
+            throw $exception;
         }
     }
 


### PR DESCRIPTION
### Descrição

Muitas pessoas que usam a biblioteca estão recebendo o erro
```
Fatal error: Call to a member function getBody() on null in vendor\pagarme\pagarme-php\src\ResponseHandler.php on line 38
```

Isso ocorre pois o tratamento da exceção estava sendo feito de forma errada. A biblioteca espera uma exceção do tipo `GuzzleHttp\Exception\ClientException`, mas é enviada uma `Exception`, que não possui o método `getResponse()->getBody();`

### Número da Issue

Sem issue.

### Testes Realizados

Testes unitários, para garantir que ClientException sejam redirecionadas para o local correto.