### PR TITLE
Reordena a verificação de compatibilidade entre versões do Guzzle

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -80,7 +80,18 @@ class Client
      */
     private function buildRequest($apiRequest)
     {
-        if (class_exists('\\GuzzleHttp\\Message\\Request')) {
+        if (class_exists('\\GuzzleHttp\\Psr7\\Request')) {
+            return new \GuzzleHttp\Psr7\Request(
+                $apiRequest->getMethod(),
+                $apiRequest->getPath(),
+                ['Content-Type' => 'application/json'],
+                json_encode($this->buildBody($apiRequest))
+            );
+        }
+
+        if (class_exists('\\GuzzleHttp\\Message\\Request')
+            && method_exists($this->client, 'createRequest')
+        ) {
             $options = array_merge(
                 $this->requestOptions,
                 ['json' => $this->buildBody($apiRequest)]
@@ -89,15 +100,6 @@ class Client
                 $apiRequest->getMethod(),
                 $apiRequest->getPath(),
                 $options
-            );
-        }
-
-        if (class_exists('\\GuzzleHttp\\Psr7\\Request')) {
-            return new \GuzzleHttp\Psr7\Request(
-                $apiRequest->getMethod(),
-                $apiRequest->getPath(),
-                ['Content-Type' => 'application/json'],
-                json_encode($this->buildBody($apiRequest))
             );
         }
 


### PR DESCRIPTION
### Descrição

Identificamos um edge case, onde um cliente teve problemas ao utilizar o https://github.com/pagarme/pagarme-magento (que depende deste sdk). Especificamente neste caso duas majors versions do guzzle estavam presentes no ambiente. Dessa forma, a verificação alterada neste PR se tornava sempre verdadeira fazendo com o que a interface pública do Guzzle (neste caso divergente dadas as duas versões) fosse chamada erroneamente.

Este PR reorganiza a prioridade dessa verificação dando prioridade à versões mais recentes e em caso de versões mais antigas do guzzle, adiciona uma verificação para validar a existência do método chamado.

### Número da Issue

Não há

### Testes Realizados

Testes manuais. Os testes unitários já existentes garantem o funcionamento do fluxo mencionado