### PR TITLE
transaction: create analyzing status

### DIFF
--- a/lib/Transaction/AbstractTransaction.php
+++ b/lib/Transaction/AbstractTransaction.php
@@ -17,6 +17,7 @@ abstract class AbstractTransaction
     const PENDING_REFUND  = 'pending_refund';
     const REFUSED         = 'refused';
     const PENDING_REVIEW  = 'pending_review';
+    const ANALYZING  = 'analyzing';
 
     /**
      * @var int
@@ -490,6 +491,14 @@ abstract class AbstractTransaction
     public function isPendingReview()
     {
         return $this->status == self::PENDING_REVIEW;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isAnalyzing()
+    {
+        return $this->status == self::ANALYZING;
     }
 
     /**


### PR DESCRIPTION
### Descrição
Adiciona o status `analyzing` na interface `AbstractTransaction` e a const `isAnalyzing`. Essa alteração é dependência para a adição do `analyzing` nas plataformas Magento e Woocommerce.
<!Insira aqui o contexto/motivo deste Pull Request.>

### Número da Issue

<!Insira aqui o número da Issue referente à este Pull Request.>

### Testes Realizados

<!Descreva aqui todos os detalhes realizados para assegurar o Pull Request. Coloque todos os dados possíveis: versões dos recursos, módulos extras adicionados ao teste :)>

<!NÃO SE ESQUEÇA DE: Marcar um dos desenvolvedores do Pagar.me para review.>
