### PR TITLE
Integra o psalm para validação de qualidade do código

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - test-code-quality
       - test-5.6
       - test-7.0
       - test-7.1
@@ -54,3 +55,17 @@ jobs:
     docker:
       - image: php:7.2-alpine
 
+  test-code-quality:
+    machine:
+      enabled: true
+    steps:
+      - checkout
+      - run:
+          name: 'Up and running php7'
+          command: 'docker-compose up'
+      - run:
+          name: 'Install dependencies'
+          command: 'docker-compose run php7 composer install -n --prefer-dist'
+      - run:
+          name: 'Finding for obvious and hard-to-spot bugs with Psalm PHP'
+          command: 'docker-compose run php7 psalm'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,15 @@ services:
     volumes:
       - .:/code
     working_dir: /code
+
+  php7:
+    build:
+      dockerfile: ./docker/php7/Dockerfile
+      context: ./
+    volumes:
+      - .:/code
+    working_dir: /code
+
   composer:
     image: pagarme/composer:php5.6
     volumes:

--- a/docker/php7/Dockerfile
+++ b/docker/php7/Dockerfile
@@ -1,0 +1,23 @@
+FROM php:7.3-cli
+
+RUN apt-get update && \
+    apt-get install -y git zip unzip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
+
+COPY composer.json composer.json
+COPY composer.lock composer.lock
+RUN composer install --prefer-dist --no-scripts --no-dev --no-autoloader > /dev/null 2>&1 && \
+    rm -rf /root/.composer
+
+# Copy codebase
+COPY . ./
+
+# Finish composer
+RUN composer dump-autoload --no-scripts --optimize > /dev/null 2>&1
+
+RUN composer global require vimeo/psalm > /dev/null 2>&1
+
+RUN ln -s /root/.composer/vendor/bin/* /usr/local/bin/ > /dev/null 2>&1

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.4.5@a0866da88e605adaa648e9f1ad37f4990650f55c">
+  <file src="src/Client.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>\ArrayObject</code>
+    </InvalidNullableReturnType>
+  </file>
+  <file src="src/ResponseHandler.php">
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$jsonError-&gt;errors</code>
+    </UndefinedPropertyFetch>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <DeprecatedMethod errorLevel="info" />
+        <DeprecatedProperty errorLevel="info" />
+        <DeprecatedClass errorLevel="info" />
+        <DeprecatedConstant errorLevel="info" />
+        <DeprecatedFunction errorLevel="info" />
+        <DeprecatedInterface errorLevel="info" />
+        <DeprecatedTrait errorLevel="info" />
+
+        <InternalMethod errorLevel="info" />
+        <InternalProperty errorLevel="info" />
+        <InternalClass errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="suppress" />
+        <MissingReturnType errorLevel="info" />
+        <MissingPropertyType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+        <MisplacedRequiredParam errorLevel="info" />
+
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingConstructor errorLevel="info" />
+        <MissingClosureParamType errorLevel="suppress" />
+        <MissingParamType errorLevel="info" />
+
+        <RedundantCondition errorLevel="info" />
+
+        <DocblockTypeContradiction errorLevel="info" />
+        <RedundantConditionGivenDocblockType errorLevel="info" />
+
+        <UnresolvableInclude errorLevel="info" />
+        <UndefinedPropertyAssignment>
+            <errorLevel type="suppress">
+                <file name="src/Routes.php" />
+            </errorLevel>
+        </UndefinedPropertyAssignment>
+
+        <UndefinedPropertyFetch>
+            <errorLevel type="suppress">
+                <file name="src/ResponseHandler.php" />
+            </errorLevel>
+        </UndefinedPropertyFetch>
+        <RawObjectIteration errorLevel="info" />
+
+        <InvalidStringClass errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/src/Anonymous.php
+++ b/src/Anonymous.php
@@ -4,6 +4,10 @@ namespace PagarMe;
 
 class Anonymous extends \stdClass
 {
+    /**
+     * @param string $methodName
+     * @param array $params
+     */
     public function __call($methodName, $params)
     {
         if (!isset($this->{$methodName})) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -173,6 +173,8 @@ class Client
      *
      * @throws \PagarMe\PagarMeException
      * @return \ArrayObject
+     *
+     * @psalm-suppress InvalidNullableReturnType
      */
     public function request($method, $uri, $options = [])
     {
@@ -186,7 +188,7 @@ class Client
                 )
             );
 
-            return ResponseHandler::success($response->getBody());
+            return ResponseHandler::success((string)$response->getBody());
         } catch (InvalidJsonException $exception) {
             throw $exception;
         } catch (ClientException $exception) {

--- a/src/Endpoints/Customers.php
+++ b/src/Endpoints/Customers.php
@@ -22,7 +22,7 @@ class Customers extends Endpoint
         );
     }
 
-    /*
+    /**
      * @param array|null $payload
      *
      * @return \ArrayObject

--- a/src/Exceptions/PagarMeException.php
+++ b/src/Exceptions/PagarMeException.php
@@ -17,6 +17,7 @@ final class PagarMeException extends \Exception
     /**
      * @param string $type
      * @param string $parameterName
+     * @param string $errorMessage
      */
     public function __construct($type, $parameterName, $errorMessage)
     {


### PR DESCRIPTION
### Descrição

**O que é o Psalm**

Uma ferramenta de análise estática de código. O objetivo é através dessa análise identificar erros de implementação, validar inputs/outputs de métodos de acordo com os tipos definidos etc.

**Como funciona**

O psalm tem como requisito o php7 apesar de poder ser utilizado em projetos baseados em php5.6. Dessa forma foi adicionado um novo container com php7 que instala o composer e o psalm (globalmente). A validação é feita executando o comando `docker-compose run php7 psalm`

### Número da Issue

Não há issue

### Testes Realizados

Validação de que nada foi quebrado usando os unitários existentes.