### PR TITLE
Adiciona novo getter para PagarMeException

### DIFF
--- a/src/Exceptions/PagarMeException.php
+++ b/src/Exceptions/PagarMeException.php
@@ -63,4 +63,12 @@ final class PagarMeException extends \Exception
     {
         return $this->parameterName;
     }
+
+    /**
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
 }


### PR DESCRIPTION
### Descrição

Cria um novo método _getter_ para retornar, em `PagarMe\Exceptions\PagarMeException`, a mensagem de erro enviada pela API.

### Número da Issue

#345 

### Testes Realizados

Nenhum teste adicionado.
