### PR TITLE
Correção de erro fatal afetando outros produtos que fazem uso dessa biblioteca

### DIFF
--- a/lib/CaseConverter.php
+++ b/lib/CaseConverter.php
@@ -4,8 +4,6 @@ namespace PagarMe\Sdk;
 
 trait CaseConverter
 {
-    use CaseConverter;
-
     /**
      * @param string $sentence
      * @return string


### PR DESCRIPTION
### Descrição
Usamos o [módulo de vocês para Magento](https://github.com/pagarme/pagarme-magento), e notamos que estava disparando um erro fatal ao visualizarmos um pedido no admin da loja:
![image](https://user-images.githubusercontent.com/4603111/79228452-d8927780-7e37-11ea-81db-07dd62894f20.png)

Essa PR visa corrigir isto.

### Testes Realizados
Testamos a visualização antes e depois dessa correção numa instância do Magento 1.9.4.1 em ambos PHP 7.2 e 7.4

@sdoblinski @zitoloco @IvanMicai @jvrmaia @rsmelo 