### PR TITLE
feature: more PHP versions to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ workflows:
       - test-7.0
       - test-7.1
       - test-7.2
+      - test-7.3
+      - test-7.4
 
 jobs:
   test-5.6: &test-template
@@ -54,6 +56,16 @@ jobs:
     <<: *test-template
     docker:
       - image: php:7.2-alpine
+
+  test-7.3:
+    <<: *test-template
+    docker:
+      - image: php:7.3-alpine
+
+  test-7.4:
+    <<: *test-template
+    docker:
+      - image: php:7.4-alpine
 
   test-code-quality:
     machine:


### PR DESCRIPTION
### Descrição

These changes will add the following PHP versions to run tests:

- PHP 7.3.17 (cli) (built: Apr 24 2020 18:12:13) ( NTS )
- PHP 7.4.5 (cli) (built: Apr 24 2020 17:39:41) ( NTS )

### Número da Issue

<!Insira aqui o número da Issue referente à este Pull Request.>

### Testes Realizados

<!Descreva aqui todos os detalhes realizados para assegurar o Pull Request. Coloque todos os dados possíveis: versões dos recursos, módulos extras adicionados ao teste :)>

<!NÃO SE ESQUEÇA DE: Marcar um dos desenvolvedores do Pagar.me para review.>
