### PR TITLE
fix: custom headers

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -150,7 +150,8 @@ class Client
             $options['headers']['User-Agent'] :
             '';
 
-        $options['headers'] = $this->addUserAgentHeaders($userAgent);
+        $options['headers']['User-Agent'] = $this->addUserAgentHeaders($userAgent);
+        $options['headers']['X-PagarMe-User-Agent'] = $this->addUserAgentHeaders($userAgent);
 
         $this->http = new HttpClient($options);
 
@@ -233,16 +234,11 @@ class Client
      * Append new keys (the default and pagarme) related to user-agent
      *
      * @param string $customUserAgent
-     * @return array
+     * @return string
      */
     private function addUserAgentHeaders($customUserAgent = '')
     {
-        return [
-            'User-Agent' => $this->buildUserAgent($customUserAgent),
-            self::PAGARME_USER_AGENT_HEADER => $this->buildUserAgent(
-                $customUserAgent
-            )
-        ];
+        return $this->buildUserAgent($customUserAgent);
     }
 
     /**

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -108,7 +108,11 @@ final class ClientTest extends TestCase
             'apiKey',
             [
                 'handler' => $handler,
-                'headers' => ['User-Agent' => 'MyCustomApplication/10.2.2']
+                'headers' => [
+                  'User-Agent' => 'MyCustomApplication/10.2.2',
+                  'X-PagarMe-Version' => '2017-07-17',
+                  'Custom-Header' => 'header',
+                ]
             ]
         );
 
@@ -124,6 +128,17 @@ final class ClientTest extends TestCase
             'MyCustomApplication/10.2.2 PHP/%s',
             phpversion()
         );
+
+        $this->assertEquals(
+            '2017-07-17',
+            $container[0]['request']->getHeaderLine('X-PagarMe-Version')
+        );
+
+        $this->assertEquals(
+            'header',
+            $container[0]['request']->getHeaderLine('Custom-Header')
+        );
+
         $this->assertEquals(
             $expectedUserAgent,
             $container[0]['request']->getHeaderLine('User-Agent')


### PR DESCRIPTION
### Descrição

Permite que headers customizados sejam enviados para a API.

Atualmente os headers estão sendo substituidos, fazendo com que a SDK não funcione com diversas versões de API.

### Número da Issue

#366 

### Testes Realizados

Testes unitarios, garantindo a presença dos headers enviados.
