### PR TITLE
Padronização do header X-PagarMe-User-Agent V4

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace PagarMe;
 
+use PagarMe\PagarMe;
 use PagarMe\RequestHandler;
 use PagarMe\ResponseHandler;
 use PagarMe\Endpoints\BankAccounts;
@@ -224,8 +225,9 @@ class Client
     private function buildUserAgent($customUserAgent = '')
     {
         return trim(sprintf(
-            '%s PHP/%s',
+            '%s pagarme-php/%s php/%s',
             $customUserAgent,
+            PagarMe::VERSION,
             phpversion()
         ));
     }

--- a/src/PagarMe.php
+++ b/src/PagarMe.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PagarMe;
+
+class PagarMe
+{
+    const VERSION = '4.1.2';
+}

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -2,6 +2,7 @@
 
 namespace PagarMe\Test;
 
+use PagarMe\PagarMe;
 use PagarMe\Client;
 use PagarMe\Exceptions\PagarMeException;
 use PagarMe\Endpoints\Endpoint;
@@ -125,7 +126,8 @@ final class ClientTest extends TestCase
         );
 
         $expectedUserAgent = sprintf(
-            'MyCustomApplication/10.2.2 PHP/%s',
+            'MyCustomApplication/10.2.2 pagarme-php/%s php/%s',
+            PagarMe::VERSION,
             phpversion()
         );
 


### PR DESCRIPTION
Com o intuito de criar a possibilidade de monitorar o uso de nossos SDKs, esse PR tem o objetivo de padronizar o **header X-PagarMe-User-Agent**, enviando a versão do sdk em uso.

Diferente [da v3](https://github.com/pagarme/pagarme-php/blob/V3/lib/PagarMe.php#L28), pelo que vi a v4 ainda não tinha a versão do SDK armazenada em uma _constant_. Adicionei isso também nesse PR.

Issue relacionada: https://github.com/pagarme/Support/issues/181