### PR TITLE
Remove self reference to fix trait import on PHP 7.4

### DIFF
--- a/lib/CaseConverter.php
+++ b/lib/CaseConverter.php
@@ -4,8 +4,6 @@ namespace PagarMe\Sdk;
 
 trait CaseConverter
 {
-    use CaseConverter;
-
     /**
      * @param string $sentence
      * @return string


### PR DESCRIPTION
### Descrição

Como visto em #354 a referência ao próprio trait gera incompatibilidade com o PHP 7.4.

Esse PR resolve o problema apresentado removendo a referência.

@willian-soaresferreira 

### Número da Issue

#354
