### PR TITLE
fix: remove the self reference

### DIFF
--- a/lib/CaseConverter.php
+++ b/lib/CaseConverter.php
@@ -4,8 +4,6 @@ namespace PagarMe\Sdk;
 
 trait CaseConverter
 {
-    use CaseConverter;
-
     /**
      * @param string $sentence
      * @return string


### PR DESCRIPTION
In order to work properly with PHP ^7.4, remove the self reference on CaseConverter trait

### Descrição

Ao atualizar o PHP para a versão 7.4, ocorre um erro fatal ao utilizar a trait CaseConverter. Isso acontece pela referência que a trait faz a ela mesma.

### Número da Issue

#354

### Testes Realizados

A suite de testes preexistente foi executa antes e depois do fix, utilizando o PHP 7.4.3. Antes da correção ocorria o seguinte erro:

```
PHP Fatal error:  Trait 'PagarMe\Sdk\CaseConverter' not found in /home/samuel/www/pagarme-php/lib/CaseConverter.php on line 5
```

Todos os testes passaram após o fix.

@zitoloco 
